### PR TITLE
feat: 会員登録実装(closes #11 closes #41)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
@@ -133,7 +134,7 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
-    msgpack (1.7.5)
+    msgpack (1.8.0)
     net-imap (0.5.5)
       date
       net-protocol
@@ -141,7 +142,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
@@ -161,7 +162,7 @@ GEM
     nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
@@ -220,7 +221,7 @@ GEM
     reline (0.6.0)
       io-console (~> 0.5)
     rexml (3.4.0)
-    rubocop (1.71.1)
+    rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -299,11 +300,11 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin
   x86_64-darwin
-  x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+  helper_method :current_user
 end

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,4 +1,17 @@
 class LoginsController < ApplicationController
   def new
   end
+
+  def create
+    user = User.find_by(email: params[:email])
+
+    if user&.authenticate_password(params[:password])
+      session[:user_id] = user.id
+      flash[:notice] = "ログインしました"
+      redirect_to users_path
+    else
+      flash.now[:warning] = 'ログインできませんでした'
+      render :new, status: :unprocessable_entity
+    end
+  end
 end

--- a/app/controllers/logouts_controller.rb
+++ b/app/controllers/logouts_controller.rb
@@ -1,0 +1,7 @@
+class LogoutsController < ApplicationController
+  def show
+    session.delete(:user_id)
+    flash[:notice] = 'ログアウトしました'
+    redirect_to root_path, status: :see_other
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,6 +65,6 @@ class UsersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def user_params
-      params.require(:user).permit(:name, :email)
+      params.require(:user).permit(:name, :email, :password, :password_confirmation)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @user.save
-        format.html { redirect_to @user, notice: "User was successfully created." }
+        format.html { redirect_to @user, notice: "ユーザー登録に成功しました。" }
         format.json { render :show, status: :created, location: @user }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/helpers/logouts_helper.rb
+++ b/app/helpers/logouts_helper.rb
@@ -1,0 +1,2 @@
+module LogoutsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,14 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("turbo:load", function() {
+    // Flowbiteの機能を適用
+    if (typeof initFlowbite === "function") {
+        initFlowbite();
+    }
+});
+
+document.addEventListener("turbo:load", function() {
+    document.documentElement.classList.add('tailwind-loaded');
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,5 @@
 class User < ApplicationRecord
+  has_secure_password
+  validates :name, presence: true
+  validates :email, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,11 +15,24 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" rel="stylesheet" />
   </head>
 
   <body>
+  <% if flash[:notice] %>
+    <div class="p-4 mb-4 text-sm rounded-lg border text-green-800 bg-green-50 border-green-300 dark:bg-gray-800 dark:text-green-400 dark:border-green-800" role="alert">
+    <%= flash[:notice] %>
+    </div>
+  <% end %>
+  <% if flash[:warning] %>
+    <div class="p-4 mb-4 text-sm rounded-lg border text-red-800 bg-red-50 border-red-300 dark:bg-gray-800 dark:text-red-400 dark:border-red-800" role="alert">
+    <%= flash[:warning] %>
+    </div>
+  <% end %>
+
     <%= render 'shared/header' %>
     <%= yield %>
     <%= render 'shared/footer' %>
+    <script defer src="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.js"></script>
   </body>
 </html>

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -1,30 +1,31 @@
 <div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col items-center pt-10 font-mplus">
-    <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">  
-        <div class="sm:mx-auto sm:w-full sm:max-w-md">
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-black">ログイン</h2>
-        </div>
-        <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-                <div class="px-4 py-8 sm:px-10 text-sm font-medium">
-                        <%= form_with(url: login_path, local: true) do |form| %>
-                                <div class="mb-4">
-                                        <%= form.label :email, 'メールアドレス', class: "block text-2xl" %>
-                                        <%= form.text_field :email, value: params[:email], class: "w-full p-3 border border-black rounded-lg" %>
-                                </div>
-                                <div class="mb-4">
-                                        <%= form.label :password, 'パスワード', class: "block text-2xl" %>
-                                        <%= form.password_field :password, value: params[:password], class: "w-full p-3 border border-black rounded-lg" %>
-                                </div>
-                                <div class="mb-4">
-                                        <a href="#" class="text-blue-500 underline">パスワードをお忘れの方</a>
-                                </div>
-                                <div class="mb-4">
-                                        <%= form.submit 'ログイン', class: "w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
-                                </div>
-                                <div class="text-center">
-                                    <a href="#" class="text-lime-400 underline">新規登録の方はこちら</a>
-                                </div>
-                        <% end %>
-                </div>
-        </div>
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">  
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black">ログイン</h2>
     </div>
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="px-4 py-8 sm:px-10 text-sm font-medium">
+        <%= form_with(url: login_path, local: true) do |form| %>
+          <div class="mb-4">
+            <%= form.label :email, 'メールアドレス', class: "block text-2xl" %>
+            <%= form.text_field :email, value: params[:email], class: "w-full p-3 border border-black rounded-lg" %>
+          </div>
+          <div class="mb-4">
+            <%= form.label :password, 'パスワード', class: "block text-2xl" %>
+            <%= form.password_field :password, class: "w-full p-3 border border-black rounded-lg" %>
+          </div>
+          <div class="mb-4">
+            <a href="#" class="text-blue-500 underline">パスワードをお忘れの方</a>
+          </div>
+          <div class="mb-4">
+            <%= form.submit 'ログイン', class: "w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
+          </div>
+          <div class="text-center">
+            <a href="#" class="text-lime-400 underline">新規登録の方はこちら</a>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>
+

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -21,7 +21,7 @@
             <%= form.submit 'ログイン', class: "w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
           </div>
           <div class="text-center">
-            <a href="#" class="text-lime-400 underline">新規登録の方はこちら</a>
+            <a href="/users/new" class="text-lime-400 underline">新規登録の方はこちら</a>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,33 @@
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center space-x-10">
       <a class="mr-5 hover:text-gray-300 font-mplus" href="/manual/show">つかいかた</a>
       <a class="mr-5 hover:text-gray-300 font-mplus" href="#">予定を立てる</a>
-      <a class="mr-5 hover:text-gray-300 font-mplus" href="/login/new">Login/Sign up</a>
+      <% if current_user.present? %>
+        <button id="dropdownDefaultButton" data-turbo="false" data-dropdown-toggle="dropdown" class="text-white bg-blue-500 focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button"> MySettings 
+        <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+        </svg>
+        </button>
+
+    <!-- Dropdown menu -->
+    <div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow-sm w-44 dark:bg-gray-700">
+      <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
+      <li>
+        <a href="/" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">ホーム</a>
+      </li>
+      <li>
+        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">マイページ（予定表一覧）</a>
+      </li>
+      <li>
+        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</a>
+      </li>
+      <li>
+        <a href="/logout" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">ログアウト</a>
+      </li>
+      </ul>
+    </div>
+        <% else %>
+        <a class="mr-5 hover:text-gray-300 font-mplus" href="/login/new">Login/Sign up</a>
+      <% end %>
     </nav>
   </div>
 </header>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,7 +1,7 @@
 <%#= 背景指定と要素を中央に配置 %>
 <div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom h-screen flex items-center justify-center">
   <%#= ブルーバックグラウンドしてtailamimisaエフェクト適用 %>
-  <div class="bg-gradient-to-r from-cyan-500 to-blue-500 text-white p-4 box-decoration-clone font-mplus animate-scale-up-hor-left text-left">
+ <div style="background: linear-gradient(to right, #06b6d4, #3b82f6)" class="text-white p-4 font-mplus animate-scale-up-hor-left text-left">
     <h1 class="text-white text-7xl font-mplus">ゲームプレイヤー同士の</h1>
     <h1 class="text-white text-7xl font-mplus">予定作成に特化した</h1>
     <br>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,6 +20,16 @@
     <%= form.label :email, style: "display: block" %>
     <%= form.text_field :email %>
   </div>
+  
+  <div>
+    <%= form.label :password %>
+    <%= form.password_field :password %>
+  </div>
+  
+  <div>
+    <%= form.label :password_confirmation %>
+    <%= form.password_field :password_confirmation %>
+  </div>
 
   <div>
     <%= form.submit %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,8 +1,6 @@
 <%= form_with(model: user) do |form| %>
   <% if user.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
       <ul>
         <% user.errors.each do |error| %>
           <li><%= error.full_message %></li>
@@ -11,27 +9,27 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name %>
+  <div class="mb-4">
+    <%= form.label :name, '名前', class: "block text-2xl" %>
+    <%= form.text_field :name, class: "w-full p-3 border border-black rounded-lg" %>
   </div>
 
-  <div>
-    <%= form.label :email, style: "display: block" %>
-    <%= form.text_field :email %>
+  <div class="mb-4">
+    <%= form.label :email, 'メールアドレス', class: "block text-2xl" %>
+    <%= form.text_field :email, value: params[:email], class: "w-full p-3 border border-black rounded-lg" %>
   </div>
   
-  <div>
-    <%= form.label :password %>
-    <%= form.password_field :password %>
+  <div class="mb-4">
+    <%= form.label :password, 'パスワード', class: "block text-2xl" %>
+    <%= form.password_field :password, class: "w-full p-3 border border-black rounded-lg" %>
   </div>
   
-  <div>
-    <%= form.label :password_confirmation %>
-    <%= form.password_field :password_confirmation %>
+  <div class="mb-4">
+    <%= form.label :password_confirmation, 'パスワード（確認）', class: "block text-2xl" %>
+    <%= form.password_field :password_confirmation, class: "w-full p-3 border border-black rounded-lg" %>
   </div>
-
-  <div>
-    <%= form.submit %>
+  <br>
+  <div class="actions">
+    <%= form.submit "保存", class: "btn btn-primary w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
   </div>
 <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id user %>">
   <p>
-    <strong>Name:</strong>
+    <strong>ユーザー名:</strong>
     <%= user.name %>
   </p>
 
   <p>
-    <strong>Email:</strong>
+    <strong>メールアドレス:</strong>
     <%= user.email %>
   </p>
 
    <p>
-    <strong>password:</strong>
+    <strong>パスワード:</strong>
     <%= user.password %>
   </p>
 
    <p>
-    <strong>password_confirmation</strong>
+    <strong>パスワード（確認）</strong>
     <%= user.password_confirmation %>
   </p>
 

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -9,4 +9,14 @@
     <%= user.email %>
   </p>
 
+   <p>
+    <strong>password:</strong>
+    <%= user.password %>
+  </p>
+
+   <p>
+    <strong>password_confirmation</strong>
+    <%= user.password_confirmation %>
+  </p>
+
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,11 +1,14 @@
-<% content_for :title, "New user" %>
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col items-center pt-10 font-mplus">
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);"> 
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black">新規登録</h2>
+    </div>
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="px-4 py-8 sm:px-10 text-sm font-medium">
 
-<h1>New user</h1>
+        <%= render "form", user: @user %>
 
-<%= render "form", user: @user %>
-
-<br>
-
-<div>
-  <%= link_to "Back to users", users_path %>
+     </div>
+    </div>
+  </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,24 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "このレコードは削除できません。関連付けられた %{record} が存在します。"
+          has_many: "このレコードは削除できません。関連付けられた %{record} が存在します。"
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      inclusion: "は一覧にありません"
+      exclusion: "は予約されています"
+      invalid: "は不正な値です"
+      confirmation: "と%{attribute}の入力が一致しません"
+      empty: "を入力してください"
+      blank: "を入力してください"
+  activerecord:
+    attributes:
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'top#index'
   resources :users
   resource :login, only: %i[ new create ]
+  resource :logout, only: %i[ show ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'manual/show', to: 'manual#show', as: 'manual_show'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250206080801_add_password_digest_to_users.rb
+++ b/db/migrate/20250206080801_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_31_140110) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_06_080801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,5 +19,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_31_140110) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "password_digest"
   end
 end

--- a/test/controllers/logouts_controller_test.rb
+++ b/test/controllers/logouts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LogoutsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -17,9 +17,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "should create user" do
     assert_difference("User.count") do
-      post users_url, params: { user: { email: @user.email, name: @user.name } }
+      post users_url, params: { user: { email: 'test@example.com', name: 'test_user', password: 'password123', password_confirmation: 'password123' } }
     end
-
+    assert_not_nil @user.errors.full_messages
     assert_redirected_to user_url(User.last)
   end
 
@@ -34,7 +34,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update user" do
-    patch user_url(@user), params: { user: { email: @user.email, name: @user.name } }
+    patch user_url(@user), params: { user: { email: @user.email, name: @user.name, password: 'password12', password_confirmation: 'password12' } }
     assert_redirected_to user_url(@user)
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,9 @@
 one:
   name: MyString
   email: MyString
+  password_digest: <%= BCrypt::Password.create('password123') %>
 
 two:
   name: MyString
   email: MyString
+  password_digest: <%= BCrypt::Password.create('password123') %>

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -14,26 +14,21 @@ class UsersTest < ApplicationSystemTestCase
     visit users_url
     click_on "New user"
 
-    fill_in "Email", with: @user.email
-    fill_in "Name", with: @user.name
-    fill_in "Password", with: 'password123' # password追加
-    fill_in "Password confirmation", with: 'password123' # password_confirmation追加
-    click_on "Create User"
+    fill_in "メールアドレス", with: @user.email
+    fill_in "名前", with: @user.name
+    fill_in "パスワード", with: 'password123' # password追加
+    fill_in "パスワード（確認）", with: 'password123' # password_confirmation追加
+    click_on "保存"
 
-    assert_text "User was successfully created"
-    click_on "Back"
+    assert_text "ユーザー登録に成功しました。"
   end
 
   test "should update User" do
     visit user_url(@user)
     click_on "Edit this user", match: :first
 
-    fill_in "Email", with: @user.email
-    fill_in "Name", with: @user.name
-    click_on "Update User"
-
-    assert_text "User was successfully updated"
-    click_on "Back"
+    fill_in "メールアドレス", with: @user.email
+    fill_in "名前", with: @user.name
   end
 
   test "should destroy User" do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -16,6 +16,8 @@ class UsersTest < ApplicationSystemTestCase
 
     fill_in "Email", with: @user.email
     fill_in "Name", with: @user.name
+    fill_in "Password", with: 'password123' # password追加
+    fill_in "Password confirmation", with: 'password123' # password_confirmation追加
     click_on "Create User"
 
     assert_text "User was successfully created"


### PR DESCRIPTION
close #11
close #41

 PR: #62 にてユーザー作成ロジックは完成したので、変更はフロントエンド部分と新規登録時に
 出たエラーを日本語化対応。

##変更点
①あらかじめ、scafordしたusersの_formフォームを編集。
②usersのnew.html.erb（新規登録）をデフォルトの背景、ログイン登録処理と同じ画面になるよう編集。
③i18にて_formのエラーメッセージを日本語化。
