### PR TITLE
feat 主催者用入力フォームとDB周り実装(closes #45, closes #12)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,4 @@ group :test do
 end
 
 gem 'sorcery', '0.16.3'
+gem 'fullcalendar-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,10 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    fullcalendar-rails (3.9.0.0)
+      jquery-rails (>= 4.0.5, < 5.0.0)
+      jquery-ui-rails (>= 5.0.2)
+      momentjs-rails (>= 2.9.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -124,6 +128,12 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.6.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    jquery-ui-rails (7.0.0)
+      railties (>= 3.2.16)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.1)
@@ -143,6 +153,8 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
+    momentjs-rails (2.29.4.1)
+      railties (>= 3.1)
     msgpack (1.8.0)
     multi_json (1.15.0)
     multi_xml (0.7.1)
@@ -342,6 +354,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  fullcalendar-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,0 +1,5 @@
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
+@import "@fullcalendar/common/main.css";
+@import "@fullcalendar/daygrid/main.css";

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,30 @@
+class EventsController < ApplicationController
+  def new
+    @event = Event.new
+    @event.event_times.build
+  end
+
+  def create
+     puts "イベント作成時のパラメータ: #{params[:event].inspect}"
+    @event = Event.new(event_params)
+    @event.user = current_user if current_user.present?
+
+    if params[:event][:start_times].present?
+      params[:event][:start_times].each do |start_time_str|
+        @event.event_times.create(start_time: DateTime.strptime(start_time_str, '%m/%d (%a) %H時'))
+      end
+    end
+
+    if @event.save
+      redirect_to @event, notice: 'イベントが作成されました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name, :game_id, :data_center_id, :hunter_id, :lobby_id, event_times_attributes: [ :start_time ])
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,14 +1,16 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import { initializeCalendar } from './calendar';
 
 document.addEventListener("turbo:load", function() {
     // Flowbiteの機能を適用
     if (typeof initFlowbite === "function") {
         initFlowbite();
     }
-});
+    // カレンダーの初期化
+    initializeCalendar();
 
-document.addEventListener("turbo:load", function() {
+    // Tailwind CSSのクラスを追加
     document.documentElement.classList.add('tailwind-loaded');
 });

--- a/app/javascript/calendar.js
+++ b/app/javascript/calendar.js
@@ -1,0 +1,86 @@
+import { Calendar } from '@fullcalendar/core';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import jaLocale from '@fullcalendar/core/locales/ja';
+
+export function initializeCalendar() {
+    var calendarEl = document.getElementById('calendar');
+    if (calendarEl) {
+        var calendar = new Calendar(calendarEl, {
+            plugins: [dayGridPlugin, interactionPlugin],
+            initialView: 'dayGridMonth',
+            locale: jaLocale,
+            selectable: true,
+            dateClick: function(info) {
+                handleDateClick(info);
+            }
+        });
+        calendar.render();
+    }
+}
+
+function handleDateClick(info) {
+    var dateCandidates = document.getElementById('date_candidates');
+    var form = document.querySelector('form');  
+
+    var date = new Date(info.dateStr);
+    var dateStr = `${date.getMonth() + 1}/${date.getDate()} (${['日', '月', '火', '水', '木', '金', '土'][date.getDay()]})`;
+
+    // 初期時間を 00:00 に設定（ユーザーが変更可能にする）
+    var defaultTime = "00:00";
+
+    var dateTimeStr = `${dateStr} ${defaultTime}`;
+
+    var index = document.querySelectorAll('.date-group .dates input[type="hidden"]').length;
+
+    var existingCandidate = dateCandidates.querySelector('.date-group');
+    if (!existingCandidate) {
+        existingCandidate = document.createElement('div');
+        existingCandidate.className = 'p-4 border border-gray-300 rounded-md date-group';
+        dateCandidates.appendChild(existingCandidate);
+    }
+
+    var existingDatesContainer = existingCandidate.querySelector('.dates');
+    if (!existingDatesContainer) {
+        existingDatesContainer = document.createElement('div');
+        existingDatesContainer.className = 'dates mt-2 flex flex-wrap';
+        existingCandidate.appendChild(existingDatesContainer);
+    }
+
+    var existingDates = Array.from(existingDatesContainer.children).map(el => el.querySelector('input[type="hidden"]').value);
+    if (!existingDates.includes(dateTimeStr)) {
+        var newDateContainer = document.createElement('div');
+        newDateContainer.className = 'flex items-center mb-2';
+
+        var newDate = document.createElement('input');
+        newDate.type = 'hidden';
+        newDate.name = `event[event_times_attributes][${index}][start_time]`;
+        newDate.value = dateTimeStr;
+
+        var timeInput = document.createElement('input');
+        timeInput.type = 'time';
+        timeInput.value = defaultTime;
+        timeInput.className = 'ml-2 p-1 border border-gray-300 rounded-md';
+
+        // 時間が変更されたら隠しフィールドも更新
+        timeInput.addEventListener('change', function() {
+            newDate.value = `${dateStr} ${timeInput.value}`;
+            console.log("Updated hidden input value:", newDate.value); // デバッグ用
+
+            // フォームの隠しフィールドも更新
+            var hiddenInputInForm = form.querySelector(`input[name="event[event_times_attributes][${index}][start_time]"]`);
+            if (hiddenInputInForm) {
+                hiddenInputInForm.value = newDate.value;
+            }
+        });
+
+        newDateContainer.appendChild(newDate);
+        newDateContainer.appendChild(document.createTextNode(dateStr));
+        newDateContainer.appendChild(timeInput);
+        existingDatesContainer.appendChild(newDateContainer);
+
+        // フォームにも追加
+        form.appendChild(newDate.cloneNode(true));
+    }
+}
+

--- a/app/models/data_center.rb
+++ b/app/models/data_center.rb
@@ -1,0 +1,4 @@
+class DataCenter < ApplicationRecord
+  belongs_to :game, foreign_key: 'game_id'
+  has_many :events
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,7 @@
+class Event < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :game
+  belongs_to :data_center
+  has_many :event_times, dependent: :destroy
+  accepts_nested_attributes_for :event_times
+end

--- a/app/models/event_time.rb
+++ b/app/models/event_time.rb
@@ -1,0 +1,3 @@
+class EventTime < ApplicationRecord
+  belongs_to :event
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,4 @@
+class Game < ApplicationRecord
+   has_many :data_centers, foreign_key: 'game_title_id'
+   has_many :events, foreign_key: 'game_title_id'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :events
   validates :name, presence: true
   validates :email, presence: true
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,53 @@
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col pt-5 font-mplus">
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">
+    <div class="flex flex-col md:flex-row">
+      <div class="w-full md:w-1/2 pr-4">
+        <h2 class="text-2xl font-bold mt-8 mb-4 text-left">STEP1.予定を立てる</h2>
+        <%= form_with(model: @event, local: true) do |form| %>
+          <div class="grid grid-cols-1 gap-3">
+            <div class="mb-4">
+              <%= form.label :name, 'イベント名', class: "block text-2xl text-left" %>
+              <%= form.text_field :name, placeholder: "イベント名を入力してください", class: "w-full p-3 border border-black rounded-lg" %>
+            </div>
+
+            <div class="mb-4">
+              <%= form.label :game_id, 'プレイするゲーム(候補にない場合は未入力)', class: "block text-2xl text-left" %>
+              <%= form.select :game_id, options_for_select(Game.all.map { |game| [game.title, game.id] }), { prompt: '未選択' }, class: "w-full p-3 border border-black rounded-lg" %>
+            </div>
+
+            <div class="mb-4">
+              <%= form.label :data_center_id, '活動データセンター（FF14）', class: "block text-2xl text-left" %>
+              <%= form.select :data_center_id, options_for_select(DataCenter.all.map { |dc| [dc.name, dc.id] }), { prompt: '未選択' }, class: "w-full p-3 border border-black rounded-lg" %>
+            </div>
+
+            <div class="mb-4">
+              <%= form.label :hunter_id, 'ハンターID(モンハン)', class: "block text-2xl text-left" %>
+              <%= form.text_field :hunter_id, placeholder: "未入力可", class: "w-full p-3 border border-black rounded-lg" %>
+            </div>
+
+            <div class="mb-4">
+              <%= form.label :lobby_id, 'ロビーID（モンハン）', class: "block text-2xl text-left" %>
+              <%= form.text_field :lobby_id, placeholder: "未入力可", class: "w-full p-3 border border-black rounded-lg" %>
+            </div>
+          </div>
+      </div>
+
+      <div class="w-full md:w-1/2 pl-4">
+        <h2 class="text-2xl font-bold mt-8 mb-4 text-left">STEP2.日付を選択</h2>
+        <div id="calendar" class="mb-6">
+          <!-- カレンダー表示のためのコードをここに追加 -->
+        </div>
+
+        <h2 class="text-2xl font-bold mt-8 mb-4 text-left">日程候補</h2>
+        <div id="date_candidates" class="grid grid-cols-1 gap-3">
+          <!-- 日程候補を表示するためのコードをここに追加 -->
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-3 text-right">
+      <%= form.submit '登録', class: "p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/manual/show.html.erb
+++ b/app/views/manual/show.html.erb
@@ -12,7 +12,7 @@
           <% end %>
         </div>
         <% if @show_details_1 %>
-          <span class="mt-4 text-black">1.<a href="#" class="text-blue-500 underline">予定を立てる</a>を押し、STEP1をプルダウンから選択してください。</span>
+          <span class="mt-4 text-black">1.<a href="/events/new" class="text-blue-500 underline">予定を立てる</a>を押し、STEP1をプルダウンから選択してください。</span>
           <span class="mt-4 text-black">2.次にカレンダーから候補日にしたい日付を選択し、開始時間を編集してください。日程候補から指定した日付を確認可能（複数選択可能です）</span>
           <span class="mt-4 text-black">3.登録をボタンを押すとURLが出力されますので、参加者へ送信してください。</span>
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     </a>
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center space-x-10">
       <a class="mr-5 hover:text-gray-300 font-mplus" href="/manual/show">つかいかた</a>
-      <a class="mr-5 hover:text-gray-300 font-mplus" href="#">予定を立てる</a>
+      <a class="mr-5 hover:text-gray-300 font-mplus" href="/events/new">予定を立てる</a>
       <% if current_user.present? %>
         <button id="dropdownDefaultButton" data-turbo="false" data-dropdown-toggle="dropdown" class="text-white bg-blue-500 focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button"> MySettings 
         <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -9,8 +9,9 @@
     <br>
     <br>
     <div class="flex justify-end">
-      <button class="relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2">
-        <span class="relative font-mplus">>予定を立てる</span>
+      <%= link_to new_event_path, class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+      <span class="relative font-mplus">予定を立てる</span>
+      <% end %>
       </button>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resource :login, only: %i[ new create ]
   resource :logout, only: %i[ show ]
   resources :profiles, only: [ :show ]
+  resources :events
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'manual/show', to: 'manual#show', as: 'manual_show'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250210170812_create_events.rb
+++ b/db/migrate/20250210170812_create_events.rb
@@ -1,0 +1,14 @@
+class CreateEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :events do |t|
+      t.string :name
+      t.datetime :start_time
+      t.string :hunter_id
+      t.string :lobby_id
+      t.string :url
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250210172029_create_games.rb
+++ b/db/migrate/20250210172029_create_games.rb
@@ -1,0 +1,9 @@
+class CreateGames < ActiveRecord::Migration[7.2]
+  def change
+    create_table :games do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250210172748_create_data_centers.rb
+++ b/db/migrate/20250210172748_create_data_centers.rb
@@ -1,0 +1,10 @@
+class CreateDataCenters < ActiveRecord::Migration[7.2]
+  def change
+    create_table :data_centers do |t|
+      t.string :name
+      t.references :game_title, null: false, foreign_key: { to_table: :games }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250210174240_add_game_title_and_data_center_to_events.rb
+++ b/db/migrate/20250210174240_add_game_title_and_data_center_to_events.rb
@@ -1,0 +1,6 @@
+class AddGameTitleAndDataCenterToEvents < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :events, :game_title, null: false, foreign_key: { to_table: :games }
+    add_reference :events, :data_center, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250211163814_modify_data_centers.rb
+++ b/db/migrate/20250211163814_modify_data_centers.rb
@@ -1,0 +1,12 @@
+class ModifyDataCenters < ActiveRecord::Migration[7.2]
+  def change
+    # 不要なカラム(game_title_id)を削除
+    remove_column :data_centers, :game_title_id
+
+    # 新しいカラム(game_id)を追加
+    add_column :data_centers, :game_id, :bigint, null: false
+
+    # 外部キー制約を追加
+    add_foreign_key :data_centers, :games, column: :game_id
+  end
+end

--- a/db/migrate/20250211164649_modify_events_game_title_id_to_game_id.rb
+++ b/db/migrate/20250211164649_modify_events_game_title_id_to_game_id.rb
@@ -1,0 +1,12 @@
+class ModifyEventsGameTitleIdToGameId < ActiveRecord::Migration[7.2]
+  def change
+    # 不要なカラム(game_title_id)を削除
+    remove_column :events, :game_title_id
+
+    # 新しいカラム(game_id)を追加
+    add_column :events, :game_id, :bigint, null: false
+
+    # 外部キー制約を追加
+    add_foreign_key :events, :games, column: :game_id
+  end
+end

--- a/db/migrate/20250211180840_change_user_id_null_on_events.rb
+++ b/db/migrate/20250211180840_change_user_id_null_on_events.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdNullOnEvents < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :events, :user_id, true
+  end
+end

--- a/db/migrate/20250211203835_create_event_times.rb
+++ b/db/migrate/20250211203835_create_event_times.rb
@@ -1,0 +1,10 @@
+class CreateEventTimes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :event_times do |t|
+      t.references :event, null: false, foreign_key: true
+      t.datetime :start_time
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250211204139_remove_start_time_from_events.rb
+++ b/db/migrate/20250211204139_remove_start_time_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveStartTimeFromEvents < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :events, :start_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,44 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_09_101116) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_11_204139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "data_centers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "game_id", null: false
+  end
+
+  create_table "event_times", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.datetime "start_time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_times_on_event_id"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "name"
+    t.string "hunter_id"
+    t.string "lobby_id"
+    t.string "url"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "data_center_id", null: false
+    t.bigint "game_id", null: false
+    t.index ["data_center_id"], name: "index_events_on_data_center_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "games", force: :cascade do |t|
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -22,4 +57,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_09_101116) do
     t.string "crypted_password"
     t.string "salt"
   end
+
+  add_foreign_key "data_centers", "games"
+  add_foreign_key "event_times", "events"
+  add_foreign_key "events", "data_centers"
+  add_foreign_key "events", "games"
+  add_foreign_key "events", "users"
 end

--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
     "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.12",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.15" 
+    "tailwindcss": "^3.4.15"
   }
 }

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/data_centers.yml
+++ b/test/fixtures/data_centers.yml
@@ -1,9 +1,3 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  game_title: one
 
-two:
-  name: MyString
-  game_title: two

--- a/test/fixtures/data_centers.yml
+++ b/test/fixtures/data_centers.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  game_title: one
+
+two:
+  name: MyString
+  game_title: two

--- a/test/fixtures/event_times.yml
+++ b/test/fixtures/event_times.yml
@@ -1,9 +1,1 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  event: one
-  start_time: 2025-02-12 05:38:36
-
-two:
-  event: two
-  start_time: 2025-02-12 05:38:36

--- a/test/fixtures/event_times.yml
+++ b/test/fixtures/event_times.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  start_time: 2025-02-12 05:38:36
+
+two:
+  event: two
+  start_time: 2025-02-12 05:38:36

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,17 +1,1 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  name: MyString
-  start_time: 2025-02-11 02:08:12
-  hunter_id: MyString
-  lobby_id: MyString
-  url: MyString
-  user: one
-
-two:
-  name: MyString
-  start_time: 2025-02-11 02:08:12
-  hunter_id: MyString
-  lobby_id: MyString
-  url: MyString
-  user: two

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  start_time: 2025-02-11 02:08:12
+  hunter_id: MyString
+  lobby_id: MyString
+  url: MyString
+  user: one
+
+two:
+  name: MyString
+  start_time: 2025-02-11 02:08:12
+  hunter_id: MyString
+  lobby_id: MyString
+  url: MyString
+  user: two

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+
+two:
+  title: MyString

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,7 +1,1 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  title: MyString
-
-two:
-  title: MyString

--- a/test/models/data_center_test.rb
+++ b/test/models/data_center_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DataCenterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_time_test.rb
+++ b/test/models/event_time_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTimeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,23 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz#34aa0b52d0fbb1a654b596acfa595f0c7b77a77b"
   integrity sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==
 
+"@fullcalendar/core@^6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/core/-/core-6.1.15.tgz#6c3f5259fc4589870228853072131219bb533f6e"
+  integrity sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==
+  dependencies:
+    preact "~10.12.1"
+
+"@fullcalendar/daygrid@^6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz#91208b0955ba805ddad285a53ee6f53855146963"
+  integrity sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==
+
+"@fullcalendar/interaction@^6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-6.1.15.tgz#1c685d5c269388d4877b75ab2185e97d7c386cc7"
+  integrity sha512-DOTSkofizM7QItjgu7W68TvKKvN9PSEEvDJceyMbQDvlXHa7pm/WAVtAc6xSDZ9xmB1QramYoWGLHkCYbTW1rQ==
+
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
@@ -743,6 +760,11 @@ postcss@^8.4.47, postcss@^8.5.1:
     nanoid "^3.3.8"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+preact@~10.12.1:
+  version "10.12.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.12.1.tgz#8f9cb5442f560e532729b7d23d42fd1161354a21"
+  integrity sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
closes #45
closes #12 

## 追加
主催者が予定を立てる際に使用する、入力フォームを実装。
eventsのMVC作成。ER図に則りモデルにそれぞれアソシエーションを記入。

## DB
①gamesとdatacentersテーブルを追加し、ER図に則りそれぞれカラムを設定。
②参加者が指定した日付は複数選択できるものである為、追加で「event_times」テーブルを追加し、予定日と時間を
格納する事にした。

主催者用予定入力フォーム　events/newの作成。
[![Image from Gyazo](https://i.gyazo.com/084964275e74d0df5fb96c475ed39e2a.png)](https://gyazo.com/084964275e74d0df5fb96c475ed39e2a)

## ライブラリ
日付入力の為、fullcarenderを導入。導入につき下記gemを追加。
gem 'fullcalendar-rails'
fullcalendarをyarnインストール。

calender.jsにてカレンダー初期化とカレンダークリック時のロジック、
日時変更をユーザーが非同期処理にて実施できるように実装。


