### PR TITLE
feat: URL発行機能 (closes #13 , closes #43 ,fix #45)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,9 +5,11 @@ class EventsController < ApplicationController
   end
 
   def create
-     puts "イベント作成時のパラメータ: #{params[:event].inspect}"
     @event = Event.new(event_params)
     @event.user = current_user if current_user.present?
+
+    # 主催者のURLランダム作成
+    @event.url = SecureRandom.hex(10) unless @event.url.present?
 
     if params[:event][:start_times].present?
       params[:event][:start_times].each do |start_time_str|
@@ -16,15 +18,27 @@ class EventsController < ApplicationController
     end
 
     if @event.save
-      redirect_to @event, notice: 'イベントが作成されました'
+      # イベント作成後、共有用のtokenを作成
+      @schedule_input = ScheduleInput.create(
+      event_id: @event.id,
+      token: SecureRandom.hex(16)  # トークンの生成
+    )
+    redirect_to event_by_url_url(@event.url, token: @schedule_input.token), notice: '作成完了'
     else
       render :new
     end
   end
 
+  def show
+    # 表示用URLトークン取得
+    @event = Event.find_by(url: params[:url])
+    # 拡散用URLのトークンを取得
+    @schedule_input = ScheduleInput.find_by(token: params[:token]) if params[:token].present?
+  end
+
   private
 
   def event_params
-    params.require(:event).permit(:name, :game_id, :data_center_id, :hunter_id, :lobby_id, event_times_attributes: [:start_time])
+    params.require(:event).permit(:name, :game_id, :data_center_id, :hunter_id, :lobby_id, :url, event_times_attributes: [ :start_time ])
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,9 +1,10 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
+//import "@hotwired/turbo-rails"
 import "./controllers"
 import { initializeCalendar } from './calendar';
 
-document.addEventListener("turbo:load", function() {
+document.addEventListener("DOMContentLoaded", function() {
+    console.log("Initializing calendar...");
     // Flowbiteの機能を適用
     if (typeof initFlowbite === "function") {
         initFlowbite();

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,19 @@
 class Event < ApplicationRecord
+  before_create :generate_unique_url
   belongs_to :user, optional: true
-  belongs_to :game,optional:true
-  belongs_to :data_center,optional: true
+  belongs_to :game, optional: true
+  belongs_to :data_center, optional: true
   has_many :event_times, dependent: :destroy
+  has_many :schedule_inputs, dependent: :destroy
   accepts_nested_attributes_for :event_times
+
+  private
+
+  def generate_unique_url
+    # 生成重複防ぐ
+    loop do
+      self.url = SecureRandom.hex(10)
+      break unless Event.exists?(url: self.url)
+    end
+  end
 end

--- a/app/models/schedule_input.rb
+++ b/app/models/schedule_input.rb
@@ -1,0 +1,4 @@
+class ScheduleInput < ApplicationRecord
+  belongs_to :event
+  validates :token, presence: true, uniqueness: true
+end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -35,12 +35,10 @@
       <div class="w-full md:w-1/2 pl-4">
         <h2 class="text-2xl font-bold mt-8 mb-4 text-left">STEP2.日付を選択</h2>
         <div id="calendar" class="mb-6">
-          <!-- カレンダー表示のためのコードをここに追加 -->
         </div>
 
         <h2 class="text-2xl font-bold mt-8 mb-4 text-left">日程候補</h2>
         <div id="date_candidates" class="grid grid-cols-1 gap-3">
-          <!-- 日程候補を表示するためのコードをここに追加 -->
         </div>
       </div>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,18 @@
+<div class="flex items-center justify-center min-h-screen font-mplus">
+  <div class="bg-white w-full max-w-6xl mx-auto mt-[-380px] overflow-y-auto" style="max-height: calc(100vh - 160px);">
+    <h2 class="text-2xl font-bold text-left">参加者用の予定表が作成されました。</h2>
+    <h2 class="text-2xl font-bold text-left">以下のURLで予定表を共有しましょう!</h2>
+    <br>
+    <div class="border border-black text-black p-4 rounded-lg mb-4">
+     <%#= トークンからURLとクエリパラメータ付与して生成 %>  
+        <a href="<%= event_by_url_url(@event.url) %>?token=<%= @schedule_input.token %>">
+          <%= event_by_url_url(@event.url) %>?token=<%= @schedule_input.token %>
+        </a>
+    </div>
+      <div class="flex justify-center">
+        <%= link_to new_event_path, class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+          <span class="relative font-mplus">予定表表示</span>
+        <% end %>
+      </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,13 @@ Rails.application.routes.draw do
   resource :login, only: %i[ new create ]
   resource :logout, only: %i[ show ]
   resources :profiles, only: [ :show ]
-  resources :events
+  resources :events do
+    resources :schedule_inputs, only: [ :create ]
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'manual/show', to: 'manual#show', as: 'manual_show'
+  get '/events/:event_id/schedule_inputs/:token', to: 'schedule_inputs#show', as: 'event_schedule_input'
+  get '/events/url/:url', to: 'events#show', as: 'event_by_url'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250212115537_remove_not_null_constraint_from_game_id.rb
+++ b/db/migrate/20250212115537_remove_not_null_constraint_from_game_id.rb
@@ -3,4 +3,3 @@ class RemoveNotNullConstraintFromGameId < ActiveRecord::Migration[6.0]
     change_column_null :events, :game_id, true
   end
 end
-

--- a/db/migrate/20250213075108_create_schedule_inputs.rb
+++ b/db/migrate/20250213075108_create_schedule_inputs.rb
@@ -1,0 +1,15 @@
+class CreateScheduleInputs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :schedule_inputs do |t|
+      t.references :event, null: false, foreign_key: true
+      t.string :token, null: false
+      t.string :job
+      t.string :comment
+      t.string :player_name
+
+      t.timestamps
+    end
+
+    add_index :schedule_inputs, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_12_115537) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_13_075108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_115537) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "schedule_inputs", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.string "token", null: false
+    t.string "job"
+    t.string "comment"
+    t.string "player_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_schedule_inputs_on_event_id"
+    t.index ["token"], name: "index_schedule_inputs_on_token", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -63,4 +75,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_115537) do
   add_foreign_key "events", "data_centers"
   add_foreign_key "events", "games"
   add_foreign_key "events", "users"
+  add_foreign_key "schedule_inputs", "events"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,4 +14,3 @@ DataCenter.find_or_create_by!(name: 'elemental', game: ff14)
 DataCenter.find_or_create_by!(name: 'gaia', game: ff14)
 DataCenter.find_or_create_by!(name: 'mana', game: ff14)
 DataCenter.find_or_create_by!(name: 'meteor', game: ff14)
-

--- a/test/fixtures/schedule_inputs.yml
+++ b/test/fixtures/schedule_inputs.yml
@@ -1,0 +1,1 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/schedule_input_test.rb
+++ b/test/models/schedule_input_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ScheduleInputTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
fix #45 
close #43 
close #13 

## 編集
主催者用の登録ボタンがアクセス後に反応しなかったので、
非同期処理をrails turoからDomConetensでページを読ませる事にした。

## 追加
①予定作成後のURL共有フォームを/event/showに作成。
参加者が作成したデータを保存する「Scedule_Inputs」をDBに作成。
db;migrate。tokenクエリ作成用のカラム作成。

②tokenについては「secure random」を使用してランダムな値をURLに持たせ、
tokenを付与できるように実装。

③セキュリティの観点から、主催者が情報を記入後にアクセスするURLにもsecure tokenを使用。
参加者は予定を登録後に、「/id/urltoken/url+クエリ」からなるルーティングにアクセスするように実装。

### URL共有画面
[![Image from Gyazo](https://i.gyazo.com/52498927c4cdc9eb46fec6516e491760.png)](https://gyazo.com/52498927c4cdc9eb46fec6516e491760)
