### PR TITLE
feat: ユーザー入力フォーム機能実装(closes #14, closes #44)

### DIFF
--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -1,0 +1,52 @@
+class ScheduleInputsController < ApplicationController
+    before_action :set_event
+    before_action :set_schedule_input, only: [ :index ]
+
+    def new
+      @schedule_input = @event.schedule_inputs.new
+      # 各 event_time の ID をキーにした初期データをセット
+      @schedule_input.response = @event.event_times.each_with_object({}) do |event_time, hash|
+       hash[event_time.id.to_s] = nil
+       end.to_json
+    end
+
+    def create
+      @schedule_input = @event.schedule_inputs.new(schedule_input_params.except(:event_time_id))
+      # URLトークン作成
+      @schedule_input.token = SecureRandom.hex(16)
+      # JSONに変換
+      @schedule_input.response = schedule_input_params[:response].to_json
+      @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
+      if @schedule_input.save
+        redirect_to event_schedule_inputs_path(@event), notice: '登録完了しました'
+      else
+        render :new
+      end
+    end
+
+    def index
+      @schedule_inputs = @event.schedule_inputs
+    end
+
+  private
+
+  def schedule_input_params
+    params.require(:schedule_input).permit(:player_name, :job, response: {}, comment: {}, event_time_id: {})
+  end
+
+  def set_event
+  @event = Event.find(params[:event_id])
+  rescue ActiveRecord::RecordNotFound
+  flash[:alert] = "イベントが見つかりません。"
+  redirect_to root_path
+  end
+
+  def set_schedule_input
+    if params[:token].present?
+      @schedule_input = ScheduleInput.find_by(token: params[:token])
+    else
+      flash[:alert] = "スケジュール情報が見つかりません。"
+      redirect_to root_path
+    end
+  end
+end

--- a/app/helpers/schedule_inputs_helper.rb
+++ b/app/helpers/schedule_inputs_helper.rb
@@ -1,0 +1,2 @@
+module ScheduleInputsHelper
+end

--- a/app/models/event_time.rb
+++ b/app/models/event_time.rb
@@ -1,3 +1,4 @@
 class EventTime < ApplicationRecord
   belongs_to :event
+  has_many :event_times
 end

--- a/app/models/schedule_input.rb
+++ b/app/models/schedule_input.rb
@@ -1,4 +1,5 @@
 class ScheduleInput < ApplicationRecord
   belongs_to :event
+  belongs_to :event_time, optional: true
   validates :token, presence: true, uniqueness: true
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,12 +5,12 @@
     <br>
     <div class="border border-black text-black p-4 rounded-lg mb-4">
      <%#= トークンからURLとクエリパラメータ付与して生成 %>  
-        <a href="<%= event_by_url_url(@event.url) %>?token=<%= @schedule_input.token %>">
-          <%= event_by_url_url(@event.url) %>?token=<%= @schedule_input.token %>
+        <a href="<%= request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token) %>">
+    <%= request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token) %>
         </a>
     </div>
       <div class="flex justify-center">
-        <%= link_to new_event_path, class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+        <%= link_to request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token), class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
           <span class="relative font-mplus">予定表表示</span>
         <% end %>
       </div>

--- a/app/views/schedule_inputs/new.html.erb
+++ b/app/views/schedule_inputs/new.html.erb
@@ -1,0 +1,58 @@
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col pt-5 font-mplus">
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black"><%= @event.name %>日程登録</h2>
+    </div>
+    <%= form_with model: @schedule_input, url: event_schedule_inputs_path(@event), local: true do |f| %>
+      <div class="mb-4">
+        <%= f.label :player_name, 'プレイヤー名', class: "block text-2xl text-left" %>
+        <%= f.text_field :player_name, placeholder: "プレイヤー名を入力してください", class: "w-full p-3 border border-black rounded-lg" %>
+      </div>
+
+     <div class="mb-4">
+       <%= f.label :job, 'ジョブor武器(候補にない場合は未入力)', class: "block text-2xl text-left" %>
+        <% job_options = ["該当なし","タンク","ヒーラー","DPS","ガンナー","近接戦闘","遠隔戦闘"] %>
+        
+
+        <div style="max-height: 200px; overflow-y: auto;">
+        <%= f.select :job, 
+        options_for_select(job_options, "該当なし"), 
+        {}, 
+        { class: "w-full p-3 border border-black rounded-lg" } %>
+        </div>
+
+      <div class="flex flex-col w-full border-t border-r border-black mt-8">
+        <div class="flex bg-blue-500 text-white">
+          <div class="flex items-center w-32 h-10 px-2 border-b border-l border-black"><span>日付</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>〇</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>✕</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>△</span></div>
+          <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
+        </div>
+
+        <% @event.event_times.each do |event_time| %>
+          <div class="flex">
+            <div class="w-32 h-10 px-2 border-b border-l border-black flex items-center">
+              <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
+            </div>
+            <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+              <%= f.radio_button :response, 'ok', id: "response_ok_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+            </div>
+            <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+              <%= f.radio_button :response, 'ng', id: "response_ng_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+            </div>
+            <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+              <%= f.radio_button :response, 'maybe', id: "response_maybe_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+            </div>
+            <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black">
+              <%= f.text_field :comment, placeholder: "△の備考記入欄", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
+            </div>
+            <%= f.hidden_field :event_time_id, value: event_time.id, name: "schedule_input[event_time_id][#{event_time.id}]" %>
+          </div>
+        <% end %>
+      </div>
+
+      <%= f.submit "登録", class: "p-3 bg-orange-400 w-full text-white font-bold rounded-lg hover:bg-orange-500" %>
+    <% end %>
+  </div>
+</div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resource :logout, only: %i[ show ]
   resources :profiles, only: [ :show ]
   resources :events do
-    resources :schedule_inputs, only: [ :create ]
+    resources :schedule_inputs, only: [ :create, :new, :index ]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'manual/show', to: 'manual#show', as: 'manual_show'

--- a/db/migrate/20250217152529_add_response_fields_to_schedule_inputs.rb
+++ b/db/migrate/20250217152529_add_response_fields_to_schedule_inputs.rb
@@ -1,0 +1,6 @@
+class AddResponseFieldsToScheduleInputs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :schedule_inputs, :response, :string
+    add_reference :schedule_inputs, :event_time, foreign_key: true
+  end
+end

--- a/db/migrate/20250217173013_change_response_to_text_in_schedule_inputs.rb
+++ b/db/migrate/20250217173013_change_response_to_text_in_schedule_inputs.rb
@@ -1,0 +1,5 @@
+class ChangeResponseToTextInScheduleInputs < ActiveRecord::Migration[7.2]
+  def change
+    change_column :schedule_inputs, :response, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_13_075108) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_17_173013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,7 +57,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_13_075108) do
     t.string "player_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "response"
+    t.bigint "event_time_id"
     t.index ["event_id"], name: "index_schedule_inputs_on_event_id"
+    t.index ["event_time_id"], name: "index_schedule_inputs_on_event_time_id"
     t.index ["token"], name: "index_schedule_inputs_on_token", unique: true
   end
 
@@ -75,5 +78,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_13_075108) do
   add_foreign_key "events", "data_centers"
   add_foreign_key "events", "games"
   add_foreign_key "events", "users"
+  add_foreign_key "schedule_inputs", "event_times"
   add_foreign_key "schedule_inputs", "events"
 end

--- a/test/controllers/schedule_inputs_controller_test.rb
+++ b/test/controllers/schedule_inputs_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ScheduleInputsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
参加者用の予定入力フォームをScheduleInputsの「new」として作成。
主催者が入力後に飛ぶ、/event/urlのリンクも「/new」へ飛ぶよう変更。

ユーザーはフォームへ入力する値として、プレイヤー名（player_name）、ジョブ名(job)、活動可能か（response）、
△の場合の備考（comment）を入力するものとする。
[![Image from Gyazo](https://i.gyazo.com/eb49cd9b81f4e5c461e26686057b2115.jpg)](https://gyazo.com/eb49cd9b81f4e5c461e26686057b2115)


集約パスはScheduleInputsの「index」へ集約する予定。

最終的な集約前に保存しているデータ構造
[["event_id", 14],　
主催者用のイベントID 
 ["token", "3d1c30d60d7ac04e345d9c8d072af6bf"],　
トークンつきURL発行用 
 
["job", ""], 
ジョブ

 ["comment", "{\"45\"=>\"\", \"46\"=>\"\", \"47\"=>\"\"}"], 
△の場合コメント。 そのままの値だとvalidateエラーで格納できなかった為、ScheduleInputsのcreateアクションでJSONにして保存。

 ["player_name", "test114514"], 　
プレイヤー名

 ["response", "{\"45\":\"ok\",\"46\":\"ng\",\"47\":\"maybe\"}"],　
参加者のレスポンス。 そのままの値だとvalidateエラーで格納できなかった為、ScheduleInputsのcreateアクションでJSONにして保存。
 ["event_time_id", 45]]　主催者が入力した時間