### PR TITLE
feat: 集約用予定表実装(closes #24,closes #70)

### DIFF
--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -1,13 +1,16 @@
 class ScheduleInputsController < ApplicationController
     before_action :set_event
-    before_action :set_schedule_input, only: [ :index ]
-
+  
     def new
-      @schedule_input = @event.schedule_inputs.new
-      # 各 event_time の ID をキーにした初期データをセット
-      @schedule_input.response = @event.event_times.each_with_object({}) do |event_time, hash|
-       hash[event_time.id.to_s] = nil
-       end.to_json
+      @schedule_input = @event.schedule_inputs.find_by(token: params[:token])
+      
+      if @schedule_input.nil?
+        @schedule_input = @event.schedule_inputs.new
+        @schedule_input.token = SecureRandom.hex(16)
+        @schedule_input.response = @event.event_times.each_with_object({}) { |event_time, hash| hash[event_time.id.to_s] = nil }.to_json
+      else
+        @schedule_input = @event.schedule_inputs.new
+      end
     end
 
     def create
@@ -17,16 +20,20 @@ class ScheduleInputsController < ApplicationController
       # JSONに変換
       @schedule_input.response = schedule_input_params[:response].to_json
       @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
+      
       if @schedule_input.save
         redirect_to event_schedule_inputs_path(@event), notice: '登録完了しました'
       else
+        flash[:alert] = "登録に失敗しました。入力内容を確認してください"
         render :new
       end
     end
 
     def index
-      @schedule_inputs = @event.schedule_inputs
+      @schedule_inputs = @event.schedule_inputs.includes(:event_time) if @event
     end
+
+    
 
   private
 
@@ -35,10 +42,14 @@ class ScheduleInputsController < ApplicationController
   end
 
   def set_event
-  @event = Event.find(params[:event_id])
-  rescue ActiveRecord::RecordNotFound
-  flash[:alert] = "イベントが見つかりません。"
-  redirect_to root_path
+    if params[:event_id].present?
+      @event = Event.find_by(id: params[:event_id])
+    end
+  
+    unless @event
+      flash[:alert] = "イベントが見つかりません。"
+      redirect_to root_path
+    end
   end
 
   def set_schedule_input

--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -1,9 +1,8 @@
 class ScheduleInputsController < ApplicationController
     before_action :set_event
-  
+
     def new
       @schedule_input = @event.schedule_inputs.find_by(token: params[:token])
-      
       if @schedule_input.nil?
         @schedule_input = @event.schedule_inputs.new
         @schedule_input.token = SecureRandom.hex(16)
@@ -20,7 +19,7 @@ class ScheduleInputsController < ApplicationController
       # JSONに変換
       @schedule_input.response = schedule_input_params[:response].to_json
       @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
-      
+
       if @schedule_input.save
         redirect_to event_schedule_inputs_path(@event), notice: '登録完了しました'
       else
@@ -33,8 +32,6 @@ class ScheduleInputsController < ApplicationController
       @schedule_inputs = @event.schedule_inputs.includes(:event_time) if @event
     end
 
-    
-
   private
 
   def schedule_input_params
@@ -45,7 +42,7 @@ class ScheduleInputsController < ApplicationController
     if params[:event_id].present?
       @event = Event.find_by(id: params[:event_id])
     end
-  
+
     unless @event
       flash[:alert] = "イベントが見つかりません。"
       redirect_to root_path

--- a/app/views/schedule_inputs/edit.html.erb
+++ b/app/views/schedule_inputs/edit.html.erb
@@ -1,0 +1,19 @@
+<turbo-frame id="edit_schedule_input">
+  <%= form_with model: @schedule_input, url: event_schedule_input_path(@event, @schedule_input), method: :patch do |f| %>
+    <div class="mb-4">
+      <%= f.label :player_name, 'プレイヤー名', class: "block text-lg text-left" %>
+      <%= f.text_field :player_name, class: "w-full p-2 border border-black rounded-lg", readonly: true %>
+    </div>
+
+    <% @event.event_times.each do |event_time| %>
+      <div class="flex items-center">
+        <span class="w-32"><%= event_time.start_time.strftime('%m-%d %H:%M') %></span>
+        <%= f.radio_button :response, 'ok', id: "response_ok_#{event_time.id}" %> 〇
+        <%= f.radio_button :response, 'ng', id: "response_ng_#{event_time.id}" %> ✕
+        <%= f.radio_button :response, 'maybe', id: "response_maybe_#{event_time.id}" %> △
+      </div>
+    <% end %>
+
+    <%= f.submit "更新", class: "p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
+  <% end %>
+</turbo-frame>

--- a/app/views/schedule_inputs/index.html.erb
+++ b/app/views/schedule_inputs/index.html.erb
@@ -1,0 +1,113 @@
+<div class="bg-white w-full  max-w-8xl mx-auto p-3 overflow-y-auto font-mplus" style="max-height: calc(100vh - 160px);">
+  <h2 class="text-3xl text-center text-black"><%= @event.name %> 日程表</h2>
+
+  <div class="text-2xl text-lg text-black mt-1">
+    <p>ハンターID(MH): <%= @event.hunter_id.presence || "未設定" %></p>
+    <p>ロビーID(MH): <%= @event.lobby_id.presence || "未設定" %></p>
+    <p>活動DC(FF14): <%= @event.data_center&.name.presence || "未設定" %></p>
+  </div>
+
+      <% if @schedule_input.present? %>
+        <%= link_to request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token),
+        class: 'overflow-hidden rounded bg-orange-400 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+         <span class="relative font-mplus">予定表追加</span>
+      <% end %>
+    <% else %>
+      <%= link_to request.base_url + new_event_schedule_input_path(@event),
+        class: 'overflow-hidden rounded bg-orange-400 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+      <span class="relative font-mplus">予定表追加</span>
+      <% end %>
+    <% end %>
+
+    <div class="text-sm font-mplus flex items-center space-x-0.5 tracking-tight">
+      <p class="text-green-500">・活動あり</p>
+      <p class="text-red-500">・活動あるかも</p>
+      <p class="text-black">・なし</p>
+    </div>
+
+  <table class="border border-black mt-3 ">
+    <thead>
+      <tr class="bg-gray-200">
+        <th class="border border-black p-2 w-20 h-10 text-center text-sm">日付</th>
+        <% @schedule_inputs.reject { |input| input.player_name.blank? }.each do |input| %>
+          <th class="border border-black p-2 text-center w-10">
+            <div class="font-bold text-xs"><%= input.player_name %></div>
+            <div class="text-xs text-gray-600"><%= input.job.presence || "未選択" %></div>
+          </th>
+        <% end %>
+        <th class="border border-black p-2 w-32 text-center text-sm">△の備考欄</th> <!-- 右端に追加 -->
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @event.event_times.each do |event_time| %>
+         <% 
+          # 各日程のレスポンスを取得
+          responses_for_time = @schedule_inputs.reject { |input| input.player_name.blank? }
+                                .map { |input| JSON.parse(input.response)[event_time.id.to_s] rescue nil }
+                                .compact
+
+          # 背景色を決定
+          bg_color = case
+            when responses_for_time.all? { |r| r == "ok" } then "bg-green-200" # 全員〇
+            when responses_for_time.include?("ng") then "bg-white" # ✕がいる
+            when responses_for_time.all? { |r| r == "ok" || r == "maybe" } then "bg-red-200" # 〇と△のみ
+            else ""
+          end
+        %>
+
+        <tr class="<%= bg_color %>">
+
+          <!-- 縦軸（日時） -->
+          <td class="border border-black p-1 w-10 h-10 text-center text-xs"><%= event_time.start_time.strftime('%m-%d %H:%M') %></td>
+
+          <!-- 各プレイヤーの response -->
+          <% @schedule_inputs.reject { |input| input.player_name.blank? }.each do |input| %>
+            <% responses = JSON.parse(input.response) rescue {} %>
+            <td class="border border-black p-1 w-5 h-5 text-center text-xs">
+              <%= case responses[event_time.id.to_s]
+                  when "ok" then "〇"
+                  when "ng" then "✕"
+                  when "maybe" then "△"
+                  else "未定"
+                  end
+              %>
+            </td>
+          <% end %>
+
+          <!-- 右端の △の備考欄 -->
+          <td class="border border-black p-1 w-32 h-10 text-left text-xs">
+            <% comments_for_time = @schedule_inputs.map do |input|
+                comments = begin
+                  if input.comment.present?
+                    input.comment.include?("=>") ? eval(input.comment) : JSON.parse(input.comment)
+                  else
+                    {}
+                  end
+                rescue
+                  {}
+                end
+                comments[event_time.id.to_s]
+              end.compact.reject(&:blank?) %>
+
+            <% if comments_for_time.any? %>
+              <% comments_for_time.each do |comment| %>
+                <div class="text-xs text-black mt-1">・<%= comment %></div>
+              <% end %>
+            <% else %>
+              <div class="text-xs text-gray-400">未入力</div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="flex justify-center mt-6">
+    <%= link_to event_by_url_path(@event.url), class: 'p-3 bg-white border-blue-600 text-black font-bold rounded-lg' do %>
+      イベントページへ戻る
+    <% end %>
+  </div>
+</div>
+
+

--- a/app/views/schedule_inputs/new.html.erb
+++ b/app/views/schedule_inputs/new.html.erb
@@ -3,7 +3,7 @@
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <h2 class="mt-6 text-3xl font-extrabold text-center text-black"><%= @event.name %>日程登録</h2>
     </div>
-    <%= form_with model: @schedule_input, url: event_schedule_inputs_path(@event), local: true do |f| %>
+    <%= form_with model: @schedule_input, url: event_schedule_inputs_path(@event), method: :post, local: true do |f| %>
       <div class="mb-4">
         <%= f.label :player_name, 'プレイヤー名', class: "block text-2xl text-left" %>
         <%= f.text_field :player_name, placeholder: "プレイヤー名を入力してください", class: "w-full p-3 border border-black rounded-lg" %>
@@ -14,7 +14,7 @@
         <% job_options = ["該当なし","タンク","ヒーラー","DPS","ガンナー","近接戦闘","遠隔戦闘"] %>
         
 
-        <div style="max-height: 200px; overflow-y: auto;">
+        
         <%= f.select :job, 
         options_for_select(job_options, "該当なし"), 
         {}, 
@@ -45,7 +45,7 @@
               <%= f.radio_button :response, 'maybe', id: "response_maybe_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
             </div>
             <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black">
-              <%= f.text_field :comment, placeholder: "△の備考記入欄", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
+              <%= f.text_field :comment, placeholder: "（プレイヤー名必須）", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
             </div>
             <%= f.hidden_field :event_time_id, value: event_time.id, name: "schedule_input[event_time_id][#{event_time.id}]" %>
           </div>

--- a/app/views/schedule_inputs/update.turbo_stream.erb
+++ b/app/views/schedule_inputs/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<turbo-stream action="replace" target="edit_schedule_input">
+  <turbo-frame id="edit_schedule_input">
+    <%= link_to @schedule_input.player_name, edit_event_schedule_input_path(@event, @schedule_input), class: "text-blue-500 hover:underline", data: { turbo_frame: "edit_schedule_input" } %>
+  </turbo-frame>
+</turbo-stream>


### PR DESCRIPTION
参加者が入力した「/schedule/new」を集約する予定表を「/schedule/index」へ作成。
各日付を複数取得する可能性がある為、indexアクションで@event.schedule_inputsをinclude。
## 実装内容
・event_idを使用して、主催者が入力したハンターID(hunter.id)、ロビーID(lobby_id)、活動DC(data_center)を表示。

・各日程のresponseとcommentとdate_timeについてはjsonで保存していた為、json.parseして取り出し。
　①response →　json parse後に〇✕△に変換。

　②comment →△の備考欄をjsonから取り出すが、json.parseだけではnilの値が抽出できず、505エラーが出たので、json形式か　　　　　
らrailsのハッシュに変換してから抽出する事とした。

　③date_time → json parseしたものをresponse_for_timeに抽出し
　全員が可能な日は緑、✕がいる場合は無色、〇と△のみの場合は、赤色と時間が色塗りされるように実装。
　
　[![Image from Gyazo](https://i.gyazo.com/9100c8291e9c92bbb3a29a2813955f40.png)](https://gyazo.com/9100c8291e9c92bbb3a29a2813955f40)