### PR TITLE
feat: 入力情報変更機能実装(close #72 ,tweak #44)

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,12 +5,12 @@
     <br>
     <div class="border border-black text-black p-4 rounded-lg mb-4">
      <%#= トークンからURLとクエリパラメータ付与して生成 %>  
-        <a href="<%= request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token) %>">
-    <%= request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token) %>
+        <a href="<%= request.base_url + event_schedule_inputs_by_url_path(@event.url) %>">
+    <%= request.base_url + event_schedule_inputs_by_url_path(@event.url) %>
         </a>
     </div>
       <div class="flex justify-center">
-        <%= link_to request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token), class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
+        <%= link_to request.base_url + event_schedule_inputs_by_url_path(@event.url) , class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
           <span class="relative font-mplus">予定表表示</span>
         <% end %>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+   <%= javascript_include_tag "application", type: "module", "data-turbo-track": "reload" %>
     <link href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" rel="stylesheet" />
   </head>
 

--- a/app/views/schedule_inputs/edit.html.erb
+++ b/app/views/schedule_inputs/edit.html.erb
@@ -1,19 +1,56 @@
 <turbo-frame id="edit_schedule_input">
-  <%= form_with model: @schedule_input, url: event_schedule_input_path(@event, @schedule_input), method: :patch do |f| %>
-    <div class="mb-4">
-      <%= f.label :player_name, 'プレイヤー名', class: "block text-lg text-left" %>
-      <%= f.text_field :player_name, class: "w-full p-2 border border-black rounded-lg", readonly: true %>
-    </div>
-
-    <% @event.event_times.each do |event_time| %>
-      <div class="flex items-center">
-        <span class="w-32"><%= event_time.start_time.strftime('%m-%d %H:%M') %></span>
-        <%= f.radio_button :response, 'ok', id: "response_ok_#{event_time.id}" %> 〇
-        <%= f.radio_button :response, 'ng', id: "response_ng_#{event_time.id}" %> ✕
-        <%= f.radio_button :response, 'maybe', id: "response_maybe_#{event_time.id}" %> △
+  <div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col pt-5 font-mplus">
+    <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">
+      <div class="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 class="mt-6 text-3xl font-extrabold text-center text-black">日程変更</h2>
       </div>
-    <% end %>
 
-    <%= f.submit "更新", class: "p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
-  <% end %>
+      <%= form_with model: @schedule_input, url:update_event_schedule_input_by_url_path(@event.url, @schedule_input.token), method: :patch, local: false, data: { turbo_frame: "edit_schedule_input" } do |f| %>
+        <div class="mb-4">
+          <%= f.label :player_name, 'プレイヤー名', class: "block text-2xl text-left" %>
+          <%= f.text_field :player_name, value: @schedule_input.player_name, placeholder: "プレイヤー名を入力してください", class: "w-full p-3 border border-black rounded-lg" %>
+        </div>
+
+        <div class="flex flex-col w-full border-t border-r border-black mt-8">
+          <div class="flex bg-blue-500 text-white">
+            <div class="flex items-center w-32 h-10 px-2 border-b border-l border-black"><span>日付</span></div>
+            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>〇</span></div>
+            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>✕</span></div>
+            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>△</span></div>
+            <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
+          </div>
+
+          <% responses = JSON.parse(@schedule_input.response) rescue {} %>
+          <% comments = JSON.parse(@schedule_input.comment) rescue {} %>
+
+          <% @event.event_times.each do |event_time| %>
+            <div class="flex">
+              <div class="w-32 h-10 px-2 border-b border-l border-black flex items-center">
+                <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
+              </div>
+              <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+                <%= f.radio_button :response, 'ok', checked: responses[event_time.id.to_s] == "ok", id: "response_ok_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+              </div>
+              <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+                <%= f.radio_button :response, 'ng', checked: responses[event_time.id.to_s] == "ng", id: "response_ng_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+              </div>
+              <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
+                <%= f.radio_button :response, 'maybe', checked: responses[event_time.id.to_s] == "maybe", id: "response_maybe_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
+              </div>
+              <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black">
+                <%= f.text_field :comment, value: comments[event_time.id.to_s], placeholder: "△の備考記入欄", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+        
+        <div class="font-mplus flex items-center space-x-0.5 tracking-tight">
+        <%= f.submit "更新する", class: "p-3 bg-orange-400 w-2/3 text-white font-bold rounded-lg hover:bg-orange-500" %>
+      <% end %>
+
+    <div class="font-mplus flex space-x-0.5 tracking-tight">
+      <%= button_to "削除する", delete_event_schedule_input_by_url_path(@event.url, @schedule_input.token),method: :delete,data: { turbo: "false" },class: " p-3 bg-red-400 text-white font-bold rounded-lg hover:bg-red-500" %>
+    </div>
+  </div>
+</div>
 </turbo-frame>

--- a/app/views/schedule_inputs/index.html.erb
+++ b/app/views/schedule_inputs/index.html.erb
@@ -10,12 +10,12 @@
       <% if @schedule_input.present? %>
         <%= link_to request.base_url + new_event_schedule_input_path(@event, token: @schedule_input.token),
         class: 'overflow-hidden rounded bg-orange-400 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
-         <span class="relative font-mplus">予定表追加</span>
+         <span class="relative font-mplus">予定追加</span>
       <% end %>
     <% else %>
       <%= link_to request.base_url + new_event_schedule_input_path(@event),
         class: 'overflow-hidden rounded bg-orange-400 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
-      <span class="relative font-mplus">予定表追加</span>
+      <span class="relative font-mplus">予定追加</span>
       <% end %>
     <% end %>
 
@@ -31,7 +31,9 @@
         <th class="border border-black p-2 w-20 h-10 text-center text-sm">日付</th>
         <% @schedule_inputs.reject { |input| input.player_name.blank? }.each do |input| %>
           <th class="border border-black p-2 text-center w-10">
-            <div class="font-bold text-xs"><%= input.player_name %></div>
+           <div class="font-bold text-xs">
+              <%= link_to input.player_name, edit_event_schedule_input_by_url_path(url: @event.url, token: input.token), class: "text-blue-500 hover:underline" %>
+           </div>
             <div class="text-xs text-gray-600"><%= input.job.presence || "未選択" %></div>
           </th>
         <% end %>
@@ -49,6 +51,7 @@
 
           # 背景色を決定
           bg_color = case
+            when responses_for_time.empty? { |r| r ==" " } then "bg-white" # 全員未入力
             when responses_for_time.all? { |r| r == "ok" } then "bg-green-200" # 全員〇
             when responses_for_time.include?("ng") then "bg-white" # ✕がいる
             when responses_for_time.all? { |r| r == "ok" || r == "maybe" } then "bg-red-200" # 〇と△のみ
@@ -105,7 +108,7 @@
 
   <div class="flex justify-center mt-6">
     <%= link_to event_by_url_path(@event.url), class: 'p-3 bg-white border-blue-600 text-black font-bold rounded-lg' do %>
-      イベントページへ戻る
+      ⏎イベントページへ戻る
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,10 @@ Rails.application.routes.draw do
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get 'manual/show', to: 'manual#show', as: 'manual_show'
-  get '/events/:event_id/schedule_inputs/:token', to: 'schedule_inputs#show', as: 'event_schedule_input'
+  get '/events/url/:url/schedule_inputs', to: 'schedule_inputs#index', as: 'event_schedule_inputs_by_url'
+  get '/events/url/:url/schedule_inputs/:token/edit', to: 'schedule_inputs#edit', as: 'edit_event_schedule_input_by_url'
+  patch '/events/url/:url/schedule_inputs/:token', to: 'schedule_inputs#update', as: 'update_event_schedule_input_by_url'
+  delete '/events/url/:url/schedule_inputs/:token', to: 'schedule_inputs#destroy', as: 'delete_event_schedule_input_by_url'
   get '/events/url/:url', to: 'events#show', as: 'event_by_url'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
close #72 

## 変更点
参加者ユーザーが集約した予定表のURLを知っておく必要がある為、参加者へ共有するURLを「/schedule_input/index」へ変更。
こちらもeventモデルでハッシュ化したものをURLで付与。
リクエストURLプラス「events/url/e0cb60c9b89e29251a60/schedule_inputs」という形で連携する事とする。

## 追加点
参加者ユーザーの日程登録情報、及び△の場合のコメントを編集削除するページを、
「/schedule/edit」へ作成。プレイヤーネームがリンクとなり、各情報を変更可能。

編集の流れ⇓
[![Image from Gyazo](https://i.gyazo.com/459cd61d945c3cf6129e422290dc6e15.gif)](https://gyazo.com/459cd61d945c3cf6129e422290dc6e15)


※削除処理について、link_toのmethod: :deleteが使用できない為、
buttonとして代用し実装した。（javascriptのカレンダーの描画処理及び登録処理がturboを使用すると
処理が競合する為、rails turboはオフにして実装を進めています。）

主機能である日程登録機能についてはこれにて実装済みとする。