### PR TITLE
fix:ログインIDハッシュ化と△コメント不具合修正(fixes #8, fixes #72)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ end
 
 gem 'sorcery', '0.16.3'
 gem 'fullcalendar-rails'
+gem "hashid-rails", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,10 @@ GEM
       momentjs-rails (>= 2.9.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashid-rails (1.4.1)
+      activerecord (>= 4.0)
+      hashids (~> 1.0)
+    hashids (1.0.6)
     hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -355,6 +359,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   fullcalendar-rails
+  hashid-rails (~> 1.0)
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -19,6 +19,7 @@ class ScheduleInputsController < ApplicationController
       @schedule_input.token = SecureRandom.hex(16)
       # JSONに変換
       @schedule_input.response = schedule_input_params[:response].to_json
+      @schedule_input.comment = schedule_input_params[:comment].present? ? schedule_input_params[:comment].to_json : {}.to_json
       @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
 
       if @schedule_input.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  include Hashid::Rails
   has_many :events
   validates :name, presence: true
   validates :email, presence: true


### PR DESCRIPTION
fix #8 
fix #72

## 変更点

・参加者用日程調整画面にて、編集をしようとするとコメントが消えてしまう不具合があったので、
scheduleinputsコントローラーのcreateアクションにて「comment」カラムもjsonで格納し、取り出す事により修正。

・ユーザーログイン後のユーザページにて、そのままユーザーidがアドレスに含まれてしまっていたので、
gem「hash-id」を追加し、ハッシュ化。