### PR TITLE
fix: #14 参加者用登録フォーム修正

### DIFF
--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -19,13 +19,14 @@ class ScheduleInputsController < ApplicationController
       @schedule_input.token = SecureRandom.hex(16)
       # JSONに変換
       @schedule_input.response = schedule_input_params[:response].to_json
-      @schedule_input.comment = schedule_input_params[:comment].present? ? schedule_input_params[:comment].to_json : {}.to_json
+      @schedule_input.comment = schedule_input_params[:comment].values.any?(&:present?) ? schedule_input_params[:comment].to_json : nil
+      
       @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
 
       if @schedule_input.save
         redirect_to event_schedule_inputs_by_url_path(@event.url), notice: '登録完了しました'
       else
-        flash[:alert] = "登録に失敗しました。入力内容を確認してください"
+        flash[:alert] = "登録に失敗しました。入力内容に不足があります。"
         render :new
       end
     end

--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -20,7 +20,7 @@ class ScheduleInputsController < ApplicationController
       # JSONに変換
       @schedule_input.response = schedule_input_params[:response].to_json
       @schedule_input.comment = schedule_input_params[:comment].values.any?(&:present?) ? schedule_input_params[:comment].to_json : nil
-      
+
       @schedule_input.event_time_id = schedule_input_params[:event_time_id].values.first.to_i if schedule_input_params[:event_time_id].present?
 
       if @schedule_input.save

--- a/app/models/schedule_input.rb
+++ b/app/models/schedule_input.rb
@@ -2,4 +2,5 @@ class ScheduleInput < ApplicationRecord
   belongs_to :event
   belongs_to :event_time, optional: true
   validates :token, presence: true, uniqueness: true
+  validates :player_name, presence: { message: "プレイヤー名を入力してください" }
 end

--- a/app/views/schedule_inputs/edit.html.erb
+++ b/app/views/schedule_inputs/edit.html.erb
@@ -28,6 +28,7 @@
               <div class="w-32 h-10 px-2 border-b border-l border-black flex items-center">
                 <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
               </div>
+               <% responses = (@schedule_input.response.present? && @schedule_input.response != "null") ? JSON.parse(@schedule_input.response) : {} %>
               <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
                 <%= f.radio_button :response, 'ok', checked: responses[event_time.id.to_s] == "ok", id: "response_ok_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
               </div>

--- a/app/views/schedule_inputs/index.html.erb
+++ b/app/views/schedule_inputs/index.html.erb
@@ -66,7 +66,7 @@
 
           <!-- 各プレイヤーの response -->
           <% @schedule_inputs.reject { |input| input.player_name.blank? }.each do |input| %>
-            <% responses = JSON.parse(input.response) rescue {} %>
+            <% responses = (input.response.present? && input.response != "null") ? JSON.parse(input.response) : {} %>
             <td class="border border-black p-1 w-5 h-5 text-center text-xs">
               <%= case responses[event_time.id.to_s]
                   when "ok" then "〇"

--- a/app/views/schedule_inputs/new.html.erb
+++ b/app/views/schedule_inputs/new.html.erb
@@ -3,6 +3,12 @@
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <h2 class="mt-6 text-3xl font-extrabold text-center text-black"><%= @event.name %>日程登録</h2>
     </div>
+    <% if flash[:alert] %>
+      <div class="bg-red-200 text-red-700 p-2 rounded-lg mb-4">
+      <%= flash[:alert] %>
+      </div>
+    <% end %>
+  
     <%= form_with model: @schedule_input, url: event_schedule_inputs_path(@event), method: :post, local: true do |f| %>
       <div class="mb-4">
         <%= f.label :player_name, 'プレイヤー名', class: "block text-2xl text-left" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
 <footer class="text-white body-font bg-stone-500 bg-opacity-75 footer-fixed w-full">
   <div class="container px-5 py-8 mx-auto flex flex-col items-center">
     <div class="flex flex-col md:flex-row items-center justify-center space-y-4 md:space-y-0 md:space-x-44">
-      <a class="text-white font-mplus" href="#">お問い合わせ</a>
-      <a class="text-white font-mplus" href="#">プライバシーポリシー</a>
-      <a class="text-white font-mplus" href="#">利用規約</a>
+      <p class="text-white font-mplus">お問い合わせ</p>
+      <p class="text-white font-mplus">プライバシーポリシー</p>
+      <p class="text-white font-mplus">利用規約</p>
     </div>
     <p class="text-sm text-white mt-4 md:mt-0 font-mplus self-center md:self-start">©2025-GamersPlanner</p>
-    <a class="text-white font-mplus md:end-start" href="#">GitHub</a>
+    <p class="text-white font-mplus md:end-start">GitHub</p>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
         <a href="<%= profile_path(@user) %>" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">マイページ（予定表一覧）</a>
       </li>
       <li>
-        <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</a>
+        <p class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</p>
       </li>
       <li>
         <a href="/logout" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">ログアウト</a>


### PR DESCRIPTION
fix #14 

## 変更点
①参加者用日程登録フォームにて、デフォルトの値が入っておらず、
◯✕△を未入力で登録するとエラーが出力されてしまった為、schedule_input のindexフォームへ値が空の場合空値 {}を代入。

②MVPリリースで実装していない遷移しないURLのリンクを非表示にした。

③プレイヤーネームを入力せずとも登録できてしまっていた為、validateを使い修正。