### PR TITLE
fix: #45 ヴァリデーションエラー修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,46 +14,34 @@ class EventsController < ApplicationController
   def create
     @event = Event.new(event_params)
     @event.user = current_user if current_user.present?
-    # 主催者のURLランダム作成
     @event.url = SecureRandom.hex(10) unless @event.url.present?
+
     if params[:event][:start_times].present?
       params[:event][:start_times].each do |start_time_str|
-        @event.event_times.create(start_time: DateTime.strptime(start_time_str, '%m/%d (%a) %H時'))
+        @event.event_times.build(start_time: DateTime.strptime(start_time_str, '%m/%d (%a) %H時'))
       end
     end
+
     if @event.save
-      # スケジュール入力を作成
-      @schedule_input = ScheduleInput.create(
-        event_id: @event.id,
-        token: SecureRandom.hex(16)  # トークンの生成
-      )
-      # ここで保存成功/失敗のログを出す
-      if @schedule_input.persisted?
-        Rails.logger.debug "ScheduleInput created successfully: #{@schedule_input.inspect}"
-        redirect_to event_by_url_url(@event.url, token: @schedule_input.token), notice: '作成完了'
-      else
-        Rails.logger.error "ScheduleInput creation failed: #{@schedule_input.errors.full_messages}"
-        flash[:alert] = "スケジュール入力の作成に失敗しました。"
-        redirect_to root_path
-      end
+
+      redirect_to event_by_url_path(@event.url), notice: 'イベントが作成されました。'
     else
+      flash[:alert] = "イベント作成に失敗しました。入力内容を確認してください。"
       render :new
     end
   end
 
   def show
     @event = Event.find_by(url: params[:url])
-    if params[:token].present?
-      @schedule_input = ScheduleInput.find_by(token: params[:token])
-    else
-      @schedule_input = ScheduleInput.where(event_id: @event.id).first
-    end
-
-    if @schedule_input.nil?
-      flash[:alert] = "スケジュール入力が見つかりませんでした。"
+    if @event.nil?
+      flash[:alert] = "イベントが見つかりません。"
       redirect_to root_path and return
     end
+
+    @schedule_input = @event.schedule_inputs.order(:id).first
+    # `@schedule_input` がなくてもエラーにしない
   end
+
 
   def recreate
     @new_event = @event.dup # 既存のイベントをコピー

--- a/app/models/schedule_input.rb
+++ b/app/models/schedule_input.rb
@@ -2,5 +2,5 @@ class ScheduleInput < ApplicationRecord
   belongs_to :event
   belongs_to :event_time, optional: true
   validates :token, presence: true, uniqueness: true
-  validates :player_name, presence: { message: "プレイヤー名を入力してください" }
+  validates :player_name, presence: true, on: :create
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
         <a href="<%= profile_path(@user) %>" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">マイページ（予定表一覧）</a>
       </li>
       <li>
-        <p class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</p>
+        <p class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</a>
       </li>
       <li>
         <a href="/logout" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">ログアウト</a>


### PR DESCRIPTION
fix: #45 

player_nameを必須にした為、主催者イベント作成後にホームへrenderされてしまう事象が発生。
主催者イベント作成である、eventsのcreateアクションにて事前にplayer_nameを取得してしまっていた事が原因。
eventsのcreateアクションにて取得は不要であったので削除。