### PR TITLE
feat: レスポンシブ対応とお問い合わせフォーム作成(closes #6 , closes #27, fixes #39)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <link href="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.css" rel="stylesheet" />
   </head>
 
-  <body>
+  <body class="flex flex-col min-h-screen">
   <% if flash[:notice] %>
     <div class="p-4 mb-4 text-sm rounded-lg border text-green-800 bg-green-50 border-green-300 dark:bg-gray-800 dark:text-green-400 dark:border-green-800" role="alert">
     <%= flash[:notice] %>
@@ -36,7 +36,11 @@
   <% end %>
 
     <%= render 'shared/header' %>
+
+    <main class="flex-grow w-full">
     <%= yield %>
+    </main>
+    
     <%= render 'shared/footer' %>
     <script defer src="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.js"></script>
   </body>

--- a/app/views/manual/show.html.erb
+++ b/app/views/manual/show.html.erb
@@ -12,11 +12,13 @@
           <% end %>
         </div>
         <% if @show_details_1 %>
-          <span class="mt-4 text-black">1.<a href="/events/new" class="text-blue-500 underline">予定を立てる</a>を押し、STEP1をプルダウンから選択してください。</span>
-          <span class="mt-4 text-black">2.次にカレンダーから候補日にしたい日付を選択し、開始時間を編集してください。</span>
-          <span class="text-black">日程候補から指定した日付を編集可能（複数選択可能）</span>
+          <span class="mt-4 text-black text-xs sm:text-base">1.<a href="/events/new" class="text-blue-500 underline">予定を立てる</a>を押し、STEP1をプルダウンから選択してください。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">2.次にカレンダーから候補日にしたい日付を選択し、</span>
+           <span class="text-black text-xs sm:text-base">開始時間を編集してください。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">日程候補から指定した日付を編集可能（複数選択可能）</span>
            <%= image_tag "manual_1.png", class: "w-50 h-50 object-cover" %>
-          <span class="mt-4 text-black">3.登録をボタンを押すと予定表URLが出力されますので、参加者へ送信してください。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">3.登録をボタンを押すと予定表URLが出力されますので、</span>
+          <span class="text-black text-xs sm:text-base">参加者へ送信してください。</span>
           <%= image_tag "manual_2.png", class: "w-50 h-50 object-cover" %>
         <% end %>
       </div>
@@ -34,13 +36,13 @@
           <% end %>
         </div>
         <% if @show_details_2 %>
-          <span class="mt-4 text-black">1.予定追加を押す。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">1.予定追加を押す。</span>
             <%= image_tag "manual_3.png", class: "w-[300px] h-[250px] object-cover" %>
-          <span class="mt-4 text-black">2. プレイヤー名と、ジョブ名や使用武器をプルダウンから選択して下さい。</span>
-            <span class="text-black">3. 自分の活動可能日程を〇✕△で選択して下さい。</span>
-            <span class="text-black">（△で参加が微妙な場合は備考記入欄へ記入。あわせてプレイヤー名も記入する。）</span>
+          <span class="mt-4 text-black text-xs sm:text-base">2. プレイヤー名と、ジョブ名や使用武器をプルダウンから選択して下さい。</span>
+            <span class="mt-4 text-black text-xs sm:text-base">3. 自分の活動可能日程を〇✕△で選択して下さい。</span>
+            <span class="mt-4 text-black text-xs sm:text-base">（△で参加が微妙な場合は備考記入欄へ記入。あわせてプレイヤー名も記入する。）</span>
             <%= image_tag "manual_4.png", class: "w-50 h-50 object-cover" %>
-          <span class="mt-4 text-black">4.登録ボタンを押して、日程入力完了です。予定を変更したい場合は、作成された予定表のプレイヤー名をクリックしてください。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">4.登録ボタンを押して、日程入力完了です。予定を変更したい場合は、作成された予定表のプレイヤー名をクリックしてください。</span>
             <%= image_tag "manual_5.png", class: "w-[300px] h-[150px] object-cover" %>
         <% end %>
       </div>
@@ -58,9 +60,9 @@
           <% end %>
         </div>
         <% if @show_details_3 %>
-          <span class="mt-4 text-black">1.<a href="#" class="text-blue-500 underline">Botを連携する</a>ボタンを押し、DICORDで通知したいサーバーを選択して下さい。</span>
-          <span class="mt-4 text-black">2.予定表から全員の入力を確認後に、DISCORDで通知ボタンを押してください。</span>
-          <span class="mt-4 text-black">3.活動日当日の17時にサーバー内で活動日のリマインドがされます!</span>
+          <span class="mt-4 text-black text-xs sm:text-base">1.<a href="#" class="text-blue-500 underline">Botを連携する</a>ボタンを押し、DICORDで通知したいサーバーを選択。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">2.予定表から全員の入力を確認後に、DISCORDで通知ボタンを押す。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">3.活動日当日の17時にサーバー内で活動日のリマインドがされます!</span>
            <div class="flex justify-end">
               <button class="relative h-12 overflow-hidden rounded bg-blue-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-blue-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2">
                 <span class="relative font-mplus">>Botを連携する</span>

--- a/app/views/schedule_inputs/edit.html.erb
+++ b/app/views/schedule_inputs/edit.html.erb
@@ -11,21 +11,21 @@
           <%= f.text_field :player_name, value: @schedule_input.player_name, placeholder: "プレイヤー名を入力してください", class: "w-full p-3 border border-black rounded-lg" %>
         </div>
 
-        <div class="flex flex-col w-full border-t border-r border-black mt-8">
-          <div class="flex bg-blue-500 text-white">
-            <div class="flex items-center w-32 h-10 px-2 border-b border-l border-black"><span>日付</span></div>
-            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>〇</span></div>
-            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>✕</span></div>
-            <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>△</span></div>
-            <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
-          </div>
+      <div class="flex flex-col w-full border-t border-r border-black mt-8">
+        <div class="flex bg-blue-500 text-white">
+          <div class="flex items-center w-32 h-10 px-2 border-b border-l border-black"><span>日付</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>〇</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>✕</span></div>
+          <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>△</span></div>
+          <div class="flex items-center w-full h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
+        </div>
 
           <% responses = JSON.parse(@schedule_input.response) rescue {} %>
           <% comments = JSON.parse(@schedule_input.comment) rescue {} %>
 
           <% @event.event_times.each do |event_time| %>
             <div class="flex">
-              <div class="w-32 h-10 px-2 border-b border-l border-black flex items-center">
+              <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-sm">
                 <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
               </div>
                <% responses = (@schedule_input.response.present? && @schedule_input.response != "null") ? JSON.parse(@schedule_input.response) : {} %>
@@ -38,7 +38,7 @@
               <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
                 <%= f.radio_button :response, 'maybe', checked: responses[event_time.id.to_s] == "maybe", id: "response_maybe_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
               </div>
-              <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black">
+              <div class="flex items-center w-full h-10 px-2 border-b border-l border-black">
                 <%= f.text_field :comment, value: comments[event_time.id.to_s], placeholder: "△の備考記入欄", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
               </div>
             </div>

--- a/app/views/schedule_inputs/new.html.erb
+++ b/app/views/schedule_inputs/new.html.erb
@@ -33,12 +33,12 @@
           <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>〇</span></div>
           <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>✕</span></div>
           <div class="flex items-center w-10 h-10 border-b border-l border-black justify-center"><span>△</span></div>
-          <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
+          <div class="flex items-center w-full h-10 px-2 border-b border-l border-black"><span>△の備考記入欄</span></div>
         </div>
 
         <% @event.event_times.each do |event_time| %>
           <div class="flex">
-            <div class="w-32 h-10 px-2 border-b border-l border-black flex items-center">
+            <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-sm">
               <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
             </div>
             <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
@@ -50,7 +50,7 @@
             <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">
               <%= f.radio_button :response, 'maybe', id: "response_maybe_#{event_time.id}", name: "schedule_input[response][#{event_time.id}]" %>
             </div>
-            <div class="flex items-center flex-grow h-10 px-2 border-b border-l border-black">
+            <div class="flex items-center w-full h-10 px-2 border-b border-l border-black">
               <%= f.text_field :comment, placeholder: "（プレイヤー名必須）", class: "w-full p-1 border border-black rounded-lg", name: "schedule_input[comment][#{event_time.id}]" %>
             </div>
             <%= f.hidden_field :event_time_id, value: event_time.id, name: "schedule_input[event_time_id][#{event_time.id}]" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
-<footer class="text-white body-font bg-stone-500 bg-opacity-75 footer-fixed w-full">
-  <div class="container px-5 py-8 mx-auto flex flex-col items-center">
+<footer class="text-white body-font bg-stone-500 bg-opacity-75 w-full mt-auto">
+  <div class="container px-5 py-8 mx-auto flex flex-col">
     <div class="flex flex-col md:flex-row items-center justify-center space-y-4 md:space-y-0 md:space-x-44">
-      <p class="text-white font-mplus">お問い合わせ</p>
+      <%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfideSPtQrAMIWZeOi9Pst5N6P6Mgjs13o4xO3dTSRecK7H2Q/viewform?usp=sharing", target: "_blank", rel: "noopener noreferrer", class: "text-white font-mplus" %>
       <p class="text-white font-mplus">プライバシーポリシー</p>
       <p class="text-white font-mplus">利用規約</p>
     </div>
-    <p class="text-sm text-white mt-4 md:mt-0 font-mplus self-center md:self-start">©2025-GamersPlanner</p>
-    <p class="text-white font-mplus md:end-start">GitHub</p>
+     <%= link_to "Github", "https://github.com/Dadanngo/Gamers_Planner", target: "_blank", rel: "noopener noreferrer", class: "flex flex-col md:flex-row items-center justify-center space-y-10 md:space-y-0 md:space-x-44 mt-4" %>
+    <p class="text-sm text-white font-mplus self-center md:self-end">©2025-GamersPlanner</p>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="text-white body-font bg-blue-500">
+<header class="text-white body-font bg-blue-500 header-fixed">
   <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
     <a class="flex title-font font-medium items-center text-white mb-4 md:mb-0" href="/">
       <%= image_tag 'logo.png', alt: 'GamersPlanner Logo', class: 'w-10 h-10 text-white p-2' %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,13 +1,13 @@
 <%#= 背景指定と要素を中央に配置 %>
-<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom h-screen flex items-center justify-center">
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom h-screen flex items-center justify-center relative">
   <%#= ブルーバックグラウンドしてtailamimisaエフェクト適用 %>
- <div style="background: linear-gradient(to right, #06b6d4, #3b82f6)" class="text-white p-4 font-mplus animate-scale-up-hor-left text-left">
-    <h1 class="text-white text-7xl font-mplus">ゲームプレイヤー同士の</h1>
-    <h1 class="text-white text-7xl font-mplus">予定作成に特化した</h1>
-    <br>
-    <h1 class="text-white text-8xl font-mplus">日程調整サービス。</h1>
-    <br>
-    <br>
+ <div style="background: linear-gradient(to right, #06b6d4, #3b82f6)" class="text-white p-4 font-mplus animate-scale-up-hor-left text-left absolute top-[10%] transform -translate-y-[10%]">
+  <h1 class="text-white text-4xl sm:text-4xl md:text-6xl lg:text-7xl font-mplus">ゲームプレイヤー同士の</h1>
+  <h1 class="text-white text-4xl sm:text-4xl md:text-6xl lg:text-7xl font-mplus">予定作成に特化した</h1>
+  <br>
+  <h1 class="text-white text-4xl sm:text-4xl md:text-6xl lg:text-8xl font-mplus">日程調整サービス。</h1>
+  <br>
+  <br>
     <div class="flex justify-end">
       <%= link_to new_event_path, class: 'relative h-12 overflow-hidden rounded bg-orange-400 px-5 py-2.5 text-white transition-all duration-300 hover:bg-orange-500 hover:ring-2 hover:ring-neutral-800 hover:ring-offset-2' do %>
       <span class="relative font-mplus">予定を立てる</span>


### PR DESCRIPTION
close #6
close #27
fix #39

## 変更点
フッダーの位置を一番下に固定。

下記ページのレスポンシブ対応を実施。
①トップ画面のボーダーアニメーションの部分を上部へ移動し、文字列をレスポンシブ対応。
②「つかいかた」ページのフォント。
③　参加者用フォーム(/schedule/new)と編集フォーム(/schedule/edit)の予定表入力欄のborderが
スマホ閲覧時にうまく表示されないので、△のflex-growをw-fullにする事により解消。　

## 追加点
・お問い合わせフォームをgoogleフォームを使用して作成。リンクをフッターへ追加。
[![Image from Gyazo](https://i.gyazo.com/78719f5da157fd4e8a6fac0280476a12.png)](https://gyazo.com/78719f5da157fd4e8a6fac0280476a12)

・githubアカウントリンクをフッターへ追加。