### PR TITLE
feat: #89 ユーザーフィードバック反映

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :set_event, only: [ :recreate ]
+  before_action :set_event, only: [ :recreate, :update_lobby_id ]
   def new
     @event = Event.new
     @event.event_times.build
@@ -54,6 +54,14 @@ class EventsController < ApplicationController
     redirect_to new_event_path, notice: "再作成します。"
   end
 
+  def update_lobby_id
+    if @event.update(lobby_id: params[:event][:lobby_id])
+      render json: { lobby_id: @event.lobby_id }
+    else
+      render json: { error: "更新に失敗しました", messages: @event.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def event_params
@@ -61,6 +69,10 @@ class EventsController < ApplicationController
   end
 
   def set_event
-    @event = Event.find(params[:id])
+    if params[:id].present?
+      @event = Event.find_by(id: params[:id])
+    elsif params[:url].present?
+      @event = Event.find_by(url: params[:url])
+    end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 //import "@hotwired/turbo-rails"
 import "./controllers"
 import { initializeCalendar } from './calendar';
+import "./controllers/lobby_id_controller";
 
 document.addEventListener("DOMContentLoaded", function() {
     console.log("Initializing calendar...");

--- a/app/javascript/calendar.js
+++ b/app/javascript/calendar.js
@@ -21,14 +21,12 @@ export function initializeCalendar() {
 
 function handleDateClick(info) {
     var dateCandidates = document.getElementById('date_candidates');
-    var form = document.querySelector('form');  
+    var form = document.querySelector('form');
 
     var date = new Date(info.dateStr);
     var dateStr = `${date.getMonth() + 1}/${date.getDate()} (${['日', '月', '火', '水', '木', '金', '土'][date.getDay()]})`;
 
-    // 初期時間を 00:00 に設定（ユーザーが変更可能にする）
     var defaultTime = "00:00";
-
     var dateTimeStr = `${dateStr} ${defaultTime}`;
 
     var index = document.querySelectorAll('.date-group .dates input[type="hidden"]').length;
@@ -50,7 +48,7 @@ function handleDateClick(info) {
     var existingDates = Array.from(existingDatesContainer.children).map(el => el.querySelector('input[type="hidden"]').value);
     if (!existingDates.includes(dateTimeStr)) {
         var newDateContainer = document.createElement('div');
-        newDateContainer.className = 'flex items-center mb-2';
+        newDateContainer.className = 'flex items-center mb-2 space-x-2';
 
         var newDate = document.createElement('input');
         newDate.type = 'hidden';
@@ -65,22 +63,41 @@ function handleDateClick(info) {
         // 時間が変更されたら隠しフィールドも更新
         timeInput.addEventListener('change', function() {
             newDate.value = `${dateStr} ${timeInput.value}`;
-            console.log("Updated hidden input value:", newDate.value); // デバッグ用
+            console.log("Updated hidden input value:", newDate.value);
 
-            // フォームの隠しフィールドも更新
             var hiddenInputInForm = form.querySelector(`input[name="event[event_times_attributes][${index}][start_time]"]`);
             if (hiddenInputInForm) {
                 hiddenInputInForm.value = newDate.value;
             }
         });
 
+        // 日付け削除ボタン作成
+        var removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.textContent = '×';
+        removeButton.className = 'ml-2 px-2 py-1 text-white bg-red-500 rounded hover:bg-red-600';
+
+        // 削除ボタンのイベントリスナー
+        removeButton.addEventListener('click', function() {
+            newDateContainer.remove(); // 表示削除
+            var hiddenInputInForm = form.querySelector(`input[name="event[event_times_attributes][${index}][start_time]"]`);
+            if (hiddenInputInForm) {
+                hiddenInputInForm.remove(); // フォームの隠しフィールドも削除
+            }
+
+            // すべての候補が削除された場合、.date-group も削除
+            if (existingDatesContainer.children.length === 0) {
+                existingCandidate.remove();
+            }
+        });
+
         newDateContainer.appendChild(newDate);
         newDateContainer.appendChild(document.createTextNode(dateStr));
         newDateContainer.appendChild(timeInput);
+        newDateContainer.appendChild(removeButton);
         existingDatesContainer.appendChild(newDateContainer);
 
         // フォームにも追加
         form.appendChild(newDate.cloneNode(true));
     }
 }
-

--- a/app/javascript/controllers/lobby_id_controller.js
+++ b/app/javascript/controllers/lobby_id_controller.js
@@ -1,0 +1,39 @@
+//非同期でlobby_idを更新する。
+
+document.addEventListener("DOMContentLoaded", function() {
+    console.log("ロビーID編集スクリプト読み込み完了");
+
+    var display = document.getElementById("lobby-id-display");
+    var input = document.getElementById("lobby-id-input");
+    var saveButton = document.getElementById("lobby-id-save"); 
+    
+    if (!display || !input || !saveButton) return;
+
+    display.addEventListener("click", function() {
+        display.classList.add("hidden");
+        input.classList.remove("hidden");
+        saveButton.classList.remove("hidden");
+    });
+
+//値を保存する処理。Railsと連携するための非同期通信 (fetch API + PATCH リクエスト)
+    saveButton.addEventListener("click", function() {
+        var newValue = input.value;
+
+        fetch(display.dataset.updateUrl, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+            },
+            body: JSON.stringify({ event: { lobby_id: newValue } })
+        })
+        .then(response => response.json())
+        .then(data => {
+            display.textContent = data.lobby_id || "未設定";
+            display.classList.remove("hidden");
+            input.classList.add("hidden");
+            saveButton.classList.add("hidden");
+        })
+        .catch(error => console.error("Error:", error));
+    });
+});

--- a/app/views/schedule_inputs/edit.html.erb
+++ b/app/views/schedule_inputs/edit.html.erb
@@ -25,7 +25,7 @@
 
           <% @event.event_times.each do |event_time| %>
             <div class="flex">
-              <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-sm">
+              <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-xs">
                 <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
               </div>
                <% responses = (@schedule_input.response.present? && @schedule_input.response != "null") ? JSON.parse(@schedule_input.response) : {} %>

--- a/app/views/schedule_inputs/index.html.erb
+++ b/app/views/schedule_inputs/index.html.erb
@@ -3,7 +3,9 @@
 
   <div class="text-2xl text-lg text-black mt-1">
     <p>ハンターID(MH): <%= @event.hunter_id.presence || "未設定" %></p>
-    <p>ロビーID(MH): <%= @event.lobby_id.presence || "未設定" %></p>
+    <p>ロビーID(MH): <span id="lobby-id-display" data-update-url="<%= update_lobby_id_event_by_url_path(url: @event.url) %>"><%= @event.lobby_id.presence || "未設定" %></span></p>
+    <input type="text" id="lobby-id-input" class="hidden p-1 border border-gray-300 rounded-md" value="<%= @event.lobby_id %>">
+    <button id="lobby-id-save" class="hidden ml-2 px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600">保存</button>
     <p>活動DC(FF14): <%= @event.data_center&.name.presence || "未設定" %></p>
   </div>
 

--- a/app/views/schedule_inputs/new.html.erb
+++ b/app/views/schedule_inputs/new.html.erb
@@ -38,7 +38,7 @@
 
         <% @event.event_times.each do |event_time| %>
           <div class="flex">
-            <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-sm">
+            <div class="w-32 h-10 overflow-hidden text-ellipsis px-2 border-b border-l border-black flex items-center text-xs">
               <span><%= event_time.start_time.strftime('%Y-%m-%d %H:%M') %></span>
             </div>
             <div class="w-10 h-10 border-b border-l border-black flex justify-center items-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/events/url/:url/schedule_inputs/:token/edit', to: 'schedule_inputs#edit', as: 'edit_event_schedule_input_by_url'
   patch '/events/url/:url/schedule_inputs/:token', to: 'schedule_inputs#update', as: 'update_event_schedule_input_by_url'
   delete '/events/url/:url/schedule_inputs/:token', to: 'schedule_inputs#destroy', as: 'delete_event_schedule_input_by_url'
+  patch '/events/url/:url/update_lobby_id', to: 'events#update_lobby_id', as: 'update_lobby_id_event_by_url'
   get '/events/url/:url', to: 'events#show', as: 'event_by_url'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
close #89

実際に友人にサービスを使用してもらい、
ユーザーからのフィードバックを参考に主機能をアップデート。

①主催者が選択した日付けを削除したい。
→calender.jsへカレンダーの日付を誤って
追加してしまった場合の削除ボタンをクリックした数だけ要素として追加。

[![Image from Gyazo](https://i.gyazo.com/0a1d042a134beb9c78f9e14de12a6368.png)](https://gyazo.com/0a1d042a134beb9c78f9e14de12a6368)

②レスポンシブ対応。
→LINEで連携時にscheduleinputsの予定表入力フォームの日付フォントが
borderからはみ出して表示されてしまっているので、日付テキストのデフォルト値をtext-xsへ変更。


③ロビーIDとハンターIDを/shcedule/indexで変更できるようにしたい。
→javascript.controllerへ非同期でロビーIDを変更する事ができるよう、定義。 
ロビーIDの表示部分 をクリックすると、入力フィールドと保存ボタンが表示される。
lobby_idを取得できなかった為、イベントIDから値を取得していたが、urlからも取得できるようにset_eventsを修正。

[![Image from Gyazo](https://i.gyazo.com/add359f06bf157a7cee82d9040eb6050.gif)](https://gyazo.com/add359f06bf157a7cee82d9040eb6050)


