### PR TITLE
fix #86 ogp画像キャッシュクリア

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,11 +8,11 @@
     <meta property="og:title" content="Gamer's Planner">
     <meta property="og:description" content="ゲームプレイヤー同士の予定作成に特化した日程調整サービスです。モンハンとFF14に対応中。">
     <meta property="og:site_name" content="Gamer's Planner">
-    <meta property="og:image" content="https://gamers-planner.onrender.com/ogp_image.png">
+    <meta property="og:image" content="https://gamers-planner.onrender.com/ogp_image.jpg?v=2">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Gamer's Planner">
     <meta name="twitter:description" content="ゲームプレイヤー同士の予定作成に特化した日程調整サービスです。モンハンとFF14に対応中。">
-    <meta property="og:image" content="https://gamers-planner.onrender.com/ogp_image.png">
+    <meta property="og:image" content="https://gamers-planner.onrender.com/ogp_image.jpg?v=2">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="icon" href="/favicon.ico?v=3">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
fix #86

アドレスの末尾にv2を配置する事で画像がうまく処理されたので、キャッシュが原因だと判明。
それぞれのogp画像の末尾にv2をつけて対応。