### PR TITLE
discord_cronジョブ環境設定編集

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -44,5 +44,5 @@ services:
         sync: false
       - key: DATABASE_URL
         fromDatabase:
-          name: gamers-planner-db
+          name: Gamers_PlannerDB
           property: connectionString


### PR DESCRIPTION
fix #33

## 変更点
render.yaml
cronジョブの環境設定でdbの名前を本番環境のdb名へ変更。