### PR TITLE
メール認証機能実装(feat #87, #88)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'letter_opener'
+  gem 'letter_opener_web' # Web UI で履歴を確認できるオプション
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     chronic (0.10.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
@@ -163,6 +165,17 @@ GEM
     jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.4)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -382,6 +395,8 @@ DEPENDENCIES
   hashid-rails (~> 1.0)
   jbuilder
   jsbundling-rails
+  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV["MAIL_USER_NAME"]
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,12 @@
+class UserMailer < ApplicationMailer
+  def activation_needed_email(user)
+    @user = user
+    @url = activate_users_url(id: user.activation_token)
+    mail(to: user.email, subject: "アカウントを有効化してください")
+  end
+
+  def activation_success_email(user)
+    @user = user
+    mail(to: @user.email, subject: "【GamersPlanner】会員登録完了のお知らせ")
+  end
+end

--- a/app/views/user_mailer/activation_needed_email.html.erb
+++ b/app/views/user_mailer/activation_needed_email.html.erb
@@ -1,0 +1,18 @@
+<h1>会員登録は完了していません。</h1>
+<p>※このメールはシステムからの自動返信です。</p>
+<p>下記リンクをクリックし、アカウントの登録を完了して下さい。</p>
+<a href="<%= activate_users_url(id: @user.activation_token) %>">会員登録する</a>
+<br>
+<p>--------------------------------</p>
+
+<p><strong>GamersPlanner</strong></p>
+<p>
+  <%= link_to "https://gamersplanner.com", "https://gamersplanner.com", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+
+<p><strong>お問い合わせ</strong></p>
+<p>
+  <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLSfideSPtQrAMIWZeOi9Pst5N6P6Mgjs13o4xO3dTSRecK7H2Q/viewform?usp=sharing", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+
+<p>--------------------------------</p>

--- a/app/views/user_mailer/activation_success_email.html.erb
+++ b/app/views/user_mailer/activation_success_email.html.erb
@@ -1,0 +1,22 @@
+<h1>【GamersPlanner】会員登録が完了しました！</h1>
+<p>※このメールはシステムからの自動送信です。</p>
+<p><%= @user.name %> さん、</p>
+<p>この度は、GamersPlannerにご登録いただき誠にありがとうございます。</p>
+<p>パスワードはお忘れのないようお願いいたします。</p>
+<br>
+<p>会員登録すると、予定表のステータスを保存しておく事やDiscordへの連携機能を使用できます！</p>
+<p>今後ともGamersPlannerをよろしくお願いいたします。</p>
+<br>
+<p>--------------------------------</p>
+
+<p><strong>GamersPlanner</strong></p>
+<p>
+  <%= link_to "https://gamersplanner.com", "https://gamersplanner.com", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+
+<p><strong>お問い合わせ</strong></p>
+<p>
+  <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLSfideSPtQrAMIWZeOi9Pst5N6P6Mgjs13o4xO3dTSRecK7H2Q/viewform?usp=sharing", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+
+<p>--------------------------------</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,8 +40,19 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.smtp_settings = {
+  address: "smtp.gmail.com",
+  port: 587,
+  domain: "example.com",
+  authentication: "plain",
+  enable_starttls_auto: true,
+  user_name: ENV["EMAIL_USER"],
+  password: ENV["EMAIL_PASSWORD"]
+}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,18 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: "your-production-domain.com" }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV["MAIL_ADDRESS"],
+    port:                 ENV["MAIL_PORT"],
+    domain:               ENV["MAIL_DOMAIN"],
+    user_name:            ENV["MAIL_USER_NAME"],
+    password:             ENV["MAIL_PASSWORD"],
+    authentication:       ENV["MAIL_AUTHENTICATION"],
+    enable_starttls_auto: ENV["MAIL_ENABLE_STARTTLS_AUTO"] == "true"
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [ :core ]
+Rails.application.config.sorcery.submodules = [ :core, :user_activation ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -346,13 +346,13 @@ Rails.application.config.sorcery.configure do |config|
     # How many seconds before the activation code expires. nil for never expires.
     # Default: `nil`
     #
-    # user.activation_token_expiration_period =
+    user.activation_token_expiration_period = 24 * 60 * 60
 
     # REQUIRED:
     # User activation mailer class.
     # Default: `nil`
-    #
-    # user.user_activation_mailer =
+
+    user.user_activation_mailer = UserMailer
 
     # When true, sorcery will not automatically
     # send the activation details email, and allow you to
@@ -369,13 +369,11 @@ Rails.application.config.sorcery.configure do |config|
 
     # Activation needed email method on your mailer class.
     # Default: `:activation_needed_email`
-    #
-    # user.activation_needed_email_method_name =
+    user.activation_needed_email_method_name =  :activation_needed_email
 
     # Activation success email method on your mailer class.
     # Default: `:activation_success_email`
-    #
-    # user.activation_success_email_method_name =
+    user.activation_success_email_method_name = :activation_success_email
 
     # Do you want to prevent users who did not activate by email from logging in?
     # Default: `true`
@@ -564,5 +562,4 @@ Rails.application.config.sorcery.configure do |config|
   # This line must come after the 'user config' block.
   # Define which model authenticates with sorcery.
   config.user_class = "User"
-  config.submodules = [ :core ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
   root 'top#index'
-  resources :users, only: [ :show, :create, :new ]
+  resources :users, only: [ :show, :create, :new ] do
+    collection do
+      get :activate
+    end
+  end
   resource :login, only: %i[ new create ]
   resource :logout, only: %i[ show ]
   resources :notifications, only: [ :create ]

--- a/db/migrate/20250416082942_add_activation_to_users.rb
+++ b/db/migrate/20250416082942_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :activation_state, :string
+    add_column :users, :activation_token, :string
+    add_column :users, :activation_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_25_043908) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_16_082942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_25_043908) do
     t.string "discord_server_id"
     t.string "discord_channel_id"
     t.string "discord_user_id"
+    t.string "activation_state"
+    t.string "activation_token"
+    t.datetime "activation_token_expires_at"
   end
 
   add_foreign_key "data_centers", "games"

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,3 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #87 
close #88 

## 変更点
セキュリティ向上の為にsorceryを使用し、メール認証による新規会員登録機能を実装。
ユーザーが新規登録ボタンで登録→SMTP経由で入力されたアドレスにメールが行く→ユーザーはメールの
会員登録するリンクからサービスのホームへ移動→会員登録完了の流れ。

①usersテーブルに以下の認証用カラムを追加。  
ステータス(activate_state)、トークン（activate_token）,認証した時間（activation_token_expires_at）

②ルーティング　
/usersへ認証アクション、「activate」を追加。

③ sorcery.rb 
sorceryへ以下の値を定義。
activation_needed_email　→認証時の確認メール文
activation_success_email　→認証完了後のメール文
sorceryのsubmoduleを使用する為、追加。

④gem→テスト環境でメールの挙動を把握する為、letters_oppener追加。

⑤ビュー
activation_needed_email.erb　→認証時の確認メール文
[![Image from Gyazo](https://i.gyazo.com/4bf8ee2875212380be13e37530d8cacc.png)](https://gyazo.com/4bf8ee2875212380be13e37530d8cacc)

activation_success_email.erb　→認証完了後のメール文
[![Image from Gyazo](https://i.gyazo.com/830addba440229cb83b4fd05391383b5.png)](https://gyazo.com/830addba440229cb83b4fd05391383b5)

⑥本番環境「production.rb」→Gmailを使用してメール送信
　テスト環境「development.rb」→letters_oppenerを使用して、メール送信

⑦コントローラー
users_controllerへ以下を追加編集。
createアクションを編集。会員登録後にdeliverでメールを飛ばすよう変更。
メール認証のアクティベーションをする、activateアクションを追加。アクティベーション後はホームにリダイレクトされ、auto_loginで自動でログインします。
