### PR TITLE
fix: #88 メール認証機能編集

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,6 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
       if @user.save
-        UserMailer.activation_needed_email(@user).deliver_now
         redirect_to root_path, notice: "確認メールを送信しました。メールアドレスを確認して下さい。"
       else
         render :new, status: :unprocessable_entity
@@ -66,7 +65,6 @@ def activate
   if user
     user.activate!
     user.reload
-    UserMailer.activation_success_email(user).deliver_now
     auto_login(user)
     flash[:notice] = "アカウント登録が完了しました！"
     redirect_to root_path

--- a/app/views/user_mailer/activation_needed_email.html.erb
+++ b/app/views/user_mailer/activation_needed_email.html.erb
@@ -7,7 +7,7 @@
 
 <p><strong>GamersPlanner</strong></p>
 <p>
-  <%= link_to "https://gamersplanner.com", "https://gamersplanner.com", target: "_blank", rel: "noopener noreferrer" %>
+  <%= link_to "https://gamers-planner.onrender.com", "https://gamers-planner.onrender.com", target: "_blank", rel: "noopener noreferrer" %>
 </p>
 
 <p><strong>お問い合わせ</strong></p>

--- a/app/views/user_mailer/activation_success_email.html.erb
+++ b/app/views/user_mailer/activation_success_email.html.erb
@@ -11,12 +11,11 @@
 
 <p><strong>GamersPlanner</strong></p>
 <p>
-  <%= link_to "https://gamersplanner.com", "https://gamersplanner.com", target: "_blank", rel: "noopener noreferrer" %>
+  <%= link_to "https://gamers-planner.onrender.com", "https://gamers-planner.onrender.com", target: "_blank", rel: "noopener noreferrer" %>
 </p>
 
 <p><strong>お問い合わせ</strong></p>
 <p>
   <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLSfideSPtQrAMIWZeOi9Pst5N6P6Mgjs13o4xO3dTSRecK7H2Q/viewform?usp=sharing", target: "_blank", rel: "noopener noreferrer" %>
 </p>
-
 <p>--------------------------------</p>


### PR DESCRIPTION
メールが２回飛んでしまっていたので、改善。
deliverメソッドが原因で、sorcery.rbにすでにdeliverでメール送信するよう定義していた為、
userコントローラー内のdeliverメソッドを削除。