### PR TITLE
feat:パスワード更新機能実装(feats #35, #36)

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,34 @@
+class PasswordResetsController < ApplicationController
+  def new; end
+
+  def create
+    @user = User.find_by(email: params[:email])
+    @user&.deliver_reset_password_instructions!
+    # 「存在しないメールアドレスです」という旨の文言を表示すると、逆に存在するメールアドレスを特定されてしまうため、
+    # あえて成功時のメッセージを送信させている
+    flash[:notice] = "初期化メールを送信しました"
+    redirect_to root_path
+  end
+
+  def edit
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
+    not_authenticated if @user.blank?
+  end
+
+  def update
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
+
+    return not_authenticated if @user.blank?
+
+    @user.password_confirmation = params[:user][:password_confirmation]
+    if @user.change_password(params[:user][:password])
+      flash[:notice] = "パスワードを変更しました"
+      redirect_to root_path
+    else
+      flash.now[:warning] = "パスワードの変更に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,11 +2,17 @@ class UserMailer < ApplicationMailer
   def activation_needed_email(user)
     @user = user
     @url = activate_users_url(id: user.activation_token)
-    mail(to: user.email, subject: "アカウントを有効化してください")
+    mail(to: user.email, subject: "【GamersPlanner】アカウントを有効化してください")
   end
 
   def activation_success_email(user)
     @user = user
     mail(to: @user.email, subject: "【GamersPlanner】会員登録完了のお知らせ")
+  end
+
+  def reset_password_email(user)
+    @user = user
+    @url  = edit_password_reset_url(@user.reset_password_token)
+    mail(to: @user.email, subject: "【GamersPlanner】パスワード再設定のご案内")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   include Hashid::Rails
   has_many :events
   validates :name, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: { case_sensitive: false }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 end

--- a/app/views/logins/_form.html.erb
+++ b/app/views/logins/_form.html.erb
@@ -7,8 +7,8 @@
     <%= form.label :password, 'パスワード', class: "block text-2xl" %>
     <%= form.password_field :password, class: "w-full p-3 border border-black rounded-lg" %>
   </div>
-  <div class="mb-4">
-    <a href="#" class="text-blue-500 underline">パスワードをお忘れの方</a>
+  <div class="mb-4 text-blue-500 underline">
+    <%= link_to "パスワードを忘れた方はこちら", new_password_reset_path %>
   </div>
   <div class="mb-4">
     <%= form.submit 'ログイン', class: "w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,18 @@
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col items-center pt-10 font-mplus">
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">  
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black">パスワードリセット</h2>
+    </div>
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="px-4 py-8 sm:px-10 text-sm font-medium">
+        <%= form_with model: @user, url: password_reset_path(@token), method: :patch do |f| %>
+        <%= f.label :password, 'パスワード', class: "block text-2xl" %>
+        <%= f.password_field :password, class: "w-full p-3 border border-black rounded-lg" %>
+        <%= f.label :password_confirmation, 'パスワード（確認）', class: "block text-2xl" %>
+        <%= f.password_field :password_confirmation, class: "w-full p-3 border border-black rounded-lg" %>
+        <%= f.submit "再設定", class: "mt-4 px-4 py-2 bg-blue-500 text-white rounded" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,16 @@
+<div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col items-center pt-10 font-mplus">
+  <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">  
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black">パスワードリセット</h2>
+    </div>
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="px-4 py-8 sm:px-10 text-sm font-medium">
+        <%= form_with url: password_resets_path, local: true do |f| %>   
+        <%= f.label :email, 'メールアドレス', class: "block text-2xl" %>
+        <%= f.text_field :email, value: params[:email], class: "w-full p-3 border border-black rounded-lg" %>
+        <%= f.submit "再設定メールを送信", class: "mt-4 px-4 py-2 bg-blue-500 text-white rounded" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,9 +34,6 @@
           </div>
       </li>
       <li>
-        <p class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント設定変更</a>
-      </li>
-      <li>
         <a href="/logout" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">ログアウト</a>
       </li>
       </ul>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,0 +1,19 @@
+<p><%= @user.name %> さん</p>
+<br>
+<p>パスワード再発行のご依頼を受け付けました。</p>
+
+<p>こちらのリンクからパスワードの再発行を行ってください。</p>
+<p><a href="<%= @url %>"><%= @url %></a></p>
+
+<p>--------------------------------</p>
+
+<p><strong>GamersPlanner</strong></p>
+<p>
+  <%= link_to "https://gamers-planner.onrender.com", "https://gamers-planner.onrender.com", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+
+<p><strong>お問い合わせ</strong></p>
+<p>
+  <%= link_to "お問い合わせフォームはこちら", "https://docs.google.com/forms/d/e/1FAIpQLSfideSPtQrAMIWZeOi9Pst5N6P6Mgjs13o4xO3dTSRecK7H2Q/viewform?usp=sharing", target: "_blank", rel: "noopener noreferrer" %>
+</p>
+<p>--------------------------------</p>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -18,5 +18,6 @@
     <strong>パスワード（確認）</strong>
     <%= user.password_confirmation %>
   </p>
+  
 
 </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [ :core, :user_activation ]
+Rails.application.config.sorcery.submodules = [ :core, :user_activation, :reset_password ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -400,12 +400,12 @@ Rails.application.config.sorcery.configure do |config|
     # Password reset mailer class.
     # Default: `nil`
     #
-    # user.reset_password_mailer =
+    user.reset_password_mailer = UserMailer
 
     # Reset password email method on your mailer class.
     # Default: `:reset_password_email`
     #
-    # user.reset_password_email_method_name =
+    user.reset_password_email_method_name = :reset_password_email
 
     # When true, sorcery will not automatically
     # send the password reset details email, and allow you to
@@ -417,7 +417,7 @@ Rails.application.config.sorcery.configure do |config|
     # How many seconds before the reset request expires. nil for never expires.
     # Default: `nil`
     #
-    # user.reset_password_expiration_period =
+    user.reset_password_expiration_period = 1.hour
 
     # Hammering protection: how long in seconds to wait before allowing another email to be sent.
     # Default: `5 * 60`

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,17 @@ ja:
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
+        taken: "はすでに使用されています"
         restrict_dependent_destroy:
           has_one: "このレコードは削除できません。関連付けられた %{record} が存在します。"
           has_many: "このレコードは削除できません。関連付けられた %{record} が存在します。"
+    attributes:
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+
   errors:
     format: "%{attribute} %{message}"
     messages:
@@ -15,10 +23,3 @@ ja:
       confirmation: "と%{attribute}の入力が一致しません"
       empty: "を入力してください"
       blank: "を入力してください"
-  activerecord:
-    attributes:
-      user:
-        name: "名前"
-        email: "メールアドレス"
-        password: "パスワード"
-        password_confirmation: "パスワード（確認）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
   resource :login, only: %i[ new create ]
   resource :logout, only: %i[ show ]
+  resources :password_resets, only: %i[new create edit update]
   resources :notifications, only: [ :create ]
   resources :profiles, only: [ :show ]
   resources :events do

--- a/db/migrate/20250419044646_add_reset_password_to_users.rb
+++ b/db/migrate/20250419044646_add_reset_password_to_users.rb
@@ -1,0 +1,8 @@
+class AddResetPasswordToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :reset_password_token, :string
+    add_column :users, :reset_password_token_expires_at, :datetime
+
+    add_index :users, :reset_password_token
+  end
+end

--- a/db/migrate/20250419050909_add_reset_password_email_sent_at_to_users.rb
+++ b/db/migrate/20250419050909_add_reset_password_email_sent_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddResetPasswordEmailSentAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :reset_password_email_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_082942) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_19_050909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,6 +87,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_082942) do
     t.string "activation_state"
     t.string "activation_token"
     t.datetime "activation_token_expires_at"
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "data_centers", "games"


### PR DESCRIPTION
close #35 
close #36

## 追加した点
ユーザーがパスワードを失念した場合のパスワード更新機能を実装。
新規登録機能と同じく、sorceryを使用。メール認証を通してパスワードを変更する流れとなっている。
①db
sorceryの「:password_reset」を使用する為、dbにパスワード
  「reset_password_token」「reset_password_token_expires_at」「reset_password_email_sent_at」
を追加。

②ルーティング
リソースpassword_resetsをルーティング。

③コントローラー
PasswordResetsを定義。createでビューからのEmailでユーザーを識別し再登録用のアドレス着きメールを
送信。updateアクションでパスワード更新する。

④ビュー
reset_passord_email.html.erb →再登録用認証メール。
/password_reset/new →失念対象のメールアドレス入力フォーム。
/password_reset/edit　→パスワード再登録用フォーム。

⑤sorcery.rb
サブモジュール「:reset_password」を追記。