### PR TITLE
feat:google認証機能実装(feats #96, #97)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,6 @@ gem "hashid-rails", "~> 1.0"
 gem 'discordrb', '~> 3.4'
 gem 'dotenv-rails'
 gem "whenever", require: false
+gem 'omniauth-google-oauth2'
+gem 'sorcery-oauth'
+gem 'omniauth-rails_csrf_protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,21 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+    omniauth (2.1.3)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.0.1)
+      jwt (>= 2.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.7.1)
+    omniauth-oauth2 (1.7.3)
+      oauth2 (>= 1.4, < 3)
+      omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     opus-ruby (1.0.1)
       ffi
     parallel (1.26.3)
@@ -242,6 +257,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.9)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -335,6 +354,10 @@ GEM
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
       oauth2 (~> 1.0, >= 0.8.0)
+    sorcery-core (0.0.0)
+      bcrypt (~> 3.0)
+    sorcery-oauth (0.0.0)
+      sorcery-core (= 0.0.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -397,12 +420,15 @@ DEPENDENCIES
   jsbundling-rails
   letter_opener
   letter_opener_web
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)
   rubocop-rails-omakase
   selenium-webdriver
   sorcery (= 0.16.3)
+  sorcery-oauth
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,17 @@
 class ApplicationController < ActionController::Base
   include Sorcery::Controller
+  include OauthsHelper
+  before_action :require_login
   before_action :set_current_user
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def require_login
+    return if current_user
+
+    flash[:danger] = 'Googleログインが必要です'
+    redirect_to root_path
+  end
 
   private
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  skip_before_action :require_login
   before_action :set_event, only: [ :recreate, :update_lobby_id ]
   def new
     @event = Event.new

--- a/app/controllers/kiyaku_controller.rb
+++ b/app/controllers/kiyaku_controller.rb
@@ -1,4 +1,5 @@
 class KiyakuController < ApplicationController
+  skip_before_action :require_login
   def term
   end
 end

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,15 +1,19 @@
 class LoginsController < ApplicationController
+  skip_before_action :require_login
+  skip_before_action :verify_authenticity_token, only: [ :create ]
+
   def new
   end
 
   def create
     @user = login(params[:email], params[:password])
-      if @user
-        flash[:notice] = "ログインしました"
-        redirect_to profile_path(@user)
-      else
-        flash.now[:warning] = "ログインできませんでした"
-        render :new, status: :unprocessable_entity
-      end
+    if @user
+      Rails.logger.info "ログイン成功: #{@user.email}"
+      redirect_to root_path, notice: 'ログインしました'
+    else
+      Rails.logger.info "ログイン失敗: raw_params=#{params.inspect}"
+      flash.now[:alert] = 'ログインできませんでした'
+      render :new, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/logouts_controller.rb
+++ b/app/controllers/logouts_controller.rb
@@ -1,4 +1,5 @@
 class LogoutsController < ApplicationController
+  skip_before_action :require_login
   def show
     logout
     flash[:notice] = "ログアウトしました"

--- a/app/controllers/manual_controller.rb
+++ b/app/controllers/manual_controller.rb
@@ -1,4 +1,5 @@
 class ManualController < ApplicationController
+  skip_before_action :require_login
   def show
     @show_details_1 = params[:button1].present?
     @show_details_2 = params[:button2].present?

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,0 +1,45 @@
+class OauthsController < ApplicationController
+  include OauthsHelper
+  skip_before_action :require_login
+  skip_before_action :verify_authenticity_token
+
+
+  def oauth
+    redirect_to "/auth/google_oauth2", allow_other_host: true
+  end
+
+  def callback
+    user = find_or_create_from_auth_hash(auth_hash)
+    log_in(user)
+    Rails.logger.info "ログイン完了: user_id=#{user.id}, session[:user_id]=#{session[:user_id]}"
+    redirect_to root_path, notice: "Googleログインに成功しました"
+  end
+
+  def destroy
+    log_out
+    redirect_to root_path, notice: "ログアウトしました"
+  end
+
+  private
+
+  def auth_hash
+    request.env['omniauth.auth']
+  end
+
+  def find_or_create_from_auth_hash(auth_hash)
+    email = auth_hash['info']['email']
+    name  = auth_hash['info']['name']
+
+    user = User.find_or_initialize_by(email: email)
+    user.name ||= name
+
+    if user.new_record?
+      random_password = SecureRandom.urlsafe_base64(12)
+      user.password = random_password
+      user.password_confirmation = random_password
+    end
+
+    user.save!
+    user
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,5 @@
 class PasswordResetsController < ApplicationController
+  skip_before_action :require_login
   def new; end
 
   def create

--- a/app/controllers/schedule_inputs_controller.rb
+++ b/app/controllers/schedule_inputs_controller.rb
@@ -1,4 +1,5 @@
 class ScheduleInputsController < ApplicationController
+    skip_before_action :require_login
     before_action :set_event
     before_action :set_schedule_input, only: [ :edit, :update, :destroy ]
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,5 @@
 class TopController < ApplicationController
+  skip_before_action :require_login
   def index
   end
 end

--- a/app/helpers/oauths_helper.rb
+++ b/app/helpers/oauths_helper.rb
@@ -1,0 +1,15 @@
+module OauthsHelper
+  def current_user
+    return unless user_id = session[:user_id]
+    @current_user ||= User.find_by(id: user_id)
+  end
+
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
+end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: { case_sensitive: false }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  has_many :authentications, dependent: :destroy
 end

--- a/app/views/logins/_form.html.erb
+++ b/app/views/logins/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: login_path, local: true) do |form| %>
+<%= form_with url: login_path, local: true, scope: nil do |form| %>
   <div class="mb-4">
     <%= form.label :email, 'メールアドレス', class: "block text-2xl" %>
     <%= form.text_field :email, value: params[:email], class: "w-full p-3 border border-black rounded-lg" %>
@@ -13,7 +13,19 @@
   <div class="mb-4">
     <%= form.submit 'ログイン', class: "w-full p-3 bg-orange-400 text-white font-bold rounded-lg hover:bg-orange-500" %>
   </div>
-  <div class="text-center">
+     <div class="field">
+        <div class="w-full max-w-lg mb-5">
+          <div class="flex items-center">
+            <div class="flex-grow border-t border-gray-300"></div>
+            <span class="mx-2 text-xs text-gray-300">OR</span>
+            <div class="flex-grow border-t border-gray-300"></div>
+          </div>
+        </div>
+  <%= link_to "/auth/google_oauth2", data: { turbo: false }, class: "inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50" do %>
+    <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Googleロゴ" class="w-5 h-5 mr-2" loading="lazy">
+    <span>Googleでログイン</span>
+  <% end %>
+  <div class="mt-4 text-center">
     <a href="/users/new" class="text-lime-400 underline">新規登録の方はこちら</a>
   </div>
 <% end %>

--- a/app/views/oauths/callback.html.erb
+++ b/app/views/oauths/callback.html.erb
@@ -1,0 +1,2 @@
+<h1>Oauths#callback</h1>
+<p>Find me in app/views/oauths/callback.html.erb</p>

--- a/app/views/oauths/oauth.html.erb
+++ b/app/views/oauths/oauth.html.erb
@@ -1,0 +1,2 @@
+<h1>Oauths#oauth</h1>
+<p>Find me in app/views/oauths/oauth.html.erb</p>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,11 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2,
+           ENV["GOOGLE_CLIENT_ID"],
+           ENV["GOOGLE_CLIENT_SECRET"],
+           {
+             scope: 'email,profile',
+             prompt: 'select_account',
+             access_type: 'online'
+           }
+           OmniAuth.config.allowed_request_methods = %i[get]
+end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [ :core, :user_activation, :reset_password ]
+Rails.application.config.sorcery.submodules = [ :core, :user_activation, :reset_password, :external ]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -80,7 +80,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = %i[google]
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -158,10 +158,10 @@ Rails.application.config.sorcery.configure do |config|
   # config.auth0.callback_url = "https://0.0.0.0:3000/oauth/callback?provider=auth0"
   # config.auth0.site = "https://example.auth0.com"
   #
-  # config.google.key = ""
-  # config.google.secret = ""
-  # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
-  # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  config.google.key = ENV['GOOGLE_CLIENT_ID']
+  config.google.secret = ENV['GOOGLE_CLIENT_SECRET']
+  config.google.callback_url = "http://localhost:3000/oauth/callback?provider=google"
+  config.google.user_info_mapping = { email: "email", username: "name" }
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #
   # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
@@ -247,7 +247,7 @@ Rails.application.config.sorcery.configure do |config|
     # Specify username attributes, for example: [:username, :email].
     # Default: `[:email]`
     #
-    # user.username_attribute_names =
+    user.username_attribute_names = [ :email ]
 
     # Change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`
@@ -541,7 +541,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   patch '/events/url/:url/update_lobby_id', to: 'events#update_lobby_id', as: 'update_lobby_id_event_by_url'
   get '/events/url/:url', to: 'events#show', as: 'event_by_url'
   get '/discord/callback', to: 'discord#callback'
+  get '/auth/:provider/callback', to: 'oauths#callback'
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250420073339_create_authentications.rb
+++ b/db/migrate/20250420073339_create_authentications.rb
@@ -1,0 +1,13 @@
+class CreateAuthentications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :authentications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :provider, null: false
+      t.string :uid, null: false
+
+      t.timestamps
+    end
+
+    add_index :authentications, [ :provider, :uid ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_19_050909) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_20_073339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "authentications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
+    t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
 
   create_table "data_centers", force: :cascade do |t|
     t.string "name"
@@ -93,6 +103,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_19_050909) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "authentications", "users"
   add_foreign_key "data_centers", "games"
   add_foreign_key "event_times", "events"
   add_foreign_key "events", "data_centers"

--- a/test/controllers/oauths_controller_test.rb
+++ b/test/controllers/oauths_controller_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class OauthsControllerTest < ActionDispatch::IntegrationTest
+end

--- a/test/fixtures/authentications.yml
+++ b/test/fixtures/authentications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  provider: MyString
+  uid: MyString
+
+two:
+  user: two
+  provider: MyString
+  uid: MyString

--- a/test/models/authentication_test.rb
+++ b/test/models/authentication_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AuthenticationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #96 
close #97

## 追加した点
google認証機能実装に伴い、以下を追加。ミドルウェアを通してコールバック用のルーティングへ
リダイレクトする仕組みで実装した。
[![Image from Gyazo](https://i.gyazo.com/108a0f66c80e45c92de27a6fc8519778.gif)](https://gyazo.com/108a0f66c80e45c92de27a6fc8519778)

①db
google認証用テーブル「authentications」を追加。

②gem
gem 'omniauth-google-oauth2'　→google認証用のgem
gem 'omniauth-rails_csrf_protection'　→これがないと、コールバック用の
ルーティングにgetしようとするとrootingエラーを起こす為、追加。

③ルーティング
コールバック用のルーティングを定義。 get '/auth/:provider/callback', to: 'oauths#callback'

④ミドルウェア
omniauth.rbに定義。

⑤コントローラー
oauth_controllerとログイン用のヘルパーOauthsHelperを追加。
CSRFトークンエラーが解消しない為、 skip_before_action :verify_authenticity_tokenでスキップ。
callbackアクションでemailやnameを保存。
ログインにパスワードが必要だったのでSecureRandomで自動生成。パスワード保存後に自動ログインする。

## 変更点
requireログインをapplication_controllerへ定義した関係でログイン不要なすべてのコントローラーへskip require_loginを
記述。