### PR TITLE
feats: システムテスト実装(feats: #17, #95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,16 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      
+      - name: Run rspec
+        run: bundle exec rspec
 
       - name: Run tests
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare
-
-      - name: Run rspec
-        run: bundle exec rspec  
+        run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,6 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-    
-      selenium:
-        image: selenium/standalone-chrome:latest
-        ports:
-          - 4444:4444
-        options: >-
-          --health-cmd "curl --silent --fail http://localhost:4444/wd/hub/status || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3      
 
       # redis:
       #   image: redis
@@ -83,9 +73,11 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare && bundle exec rspec
+        run: bin/rails db:test:prepare
+
+      - name: Run rspec
+        run: bundle exec rspec  
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+    
+      selenium:
+        image: selenium/standalone-chrome:latest
+        ports:
+          - 4444:4444
+        options: >-
+          --health-cmd "curl --silent --fail http://localhost:4444/wd/hub/status || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3      
 
       # redis:
       #   image: redis
@@ -73,6 +83,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare && bundle exec rspec
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,8 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: bin/rails db:test:prepare 
+             bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   scan_ruby:
@@ -56,6 +56,10 @@ jobs:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
+    env:
+      RAILS_ENV: test
+      # DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test
+
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
@@ -68,16 +72,23 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      
+
+      - name: Database create and migrate
+        run: |
+          cp config/database.ci.yml config/database.yml
+          bundle exec rails assets:precompile
+          bundle exec rails db:create
+          bundle exec rails db:migrate
+
       - name: Run rspec
         run: bundle exec rspec
 
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+      # - name: Run tests
+      #   env:
+      #     RAILS_ENV: test
+      #     DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      #     # REDIS_URL: redis://localhost:6379/0
+      #   run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare 
-             bundle exec rspec
+        run: bin/rails db:test:prepare && bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
+  # gem "webdrivers"
 end
 
 gem 'sorcery', '0.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,10 +409,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-client-simple (0.9.0)
       base64
@@ -463,7 +459,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
   whenever
 
 BUNDLED WITH

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,11 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV["MAIL_USER_NAME"]
+  default from: -> {
+    if Rails.env.test?
+      'no-reply@example.com'
+    else
+      ENV["MAIL_USER_NAME"] || 'fallback@example.com'
+    end
+  }
+
   layout "mailer"
 end

--- a/compose.yml
+++ b/compose.yml
@@ -28,11 +28,18 @@ services:
     environment:
       TZ: Asia/Tokyo
       MYAPP_DATABASE_PASSWORD: "password"
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+      chrome:
+        condition: service_started
+  chrome:
+    image: seleniarm/standalone-chromium:latest
+    ports:
+    - 4444:4444
 volumes:
   bundle_data:
   postgresql_data:

--- a/config/database.ci.yml
+++ b/config/database.ci.yml
@@ -1,0 +1,8 @@
+test:
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: localhost
+  username: postgres
+  password: postgres
+  database: myapp_test

--- a/spec/factories/data_centers.rb
+++ b/spec/factories/data_centers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :data_center do
+    name { "mana" }
+    association :game
+  end
+end

--- a/spec/factories/event_times.rb
+++ b/spec/factories/event_times.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_time do
+    start_time { Time.zone.parse("2025-01-01 10:00") }
+    association :event
+  end
+end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :game do
+    title { "FF14" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,9 +4,11 @@ FactoryBot.define do
     sequence(:email) { |n| "dadatest_#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
-    activation_state { true }
-    activation_token_expires_at { Time.current }
-    reset_password_token { nil }
-    reset_password_email_sent_at { nil }
+
+    trait :activated do
+      after(:create) do |user|
+        user.activate!
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,11 +45,15 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include LoginMacros
   config.before(:each, type: :system) do
-    driven_by :remote_chrome
-    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 4444
-    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
-    Capybara.ignore_hidden_elements = false
+    if ENV["SELENIUM_DRIVER_URL"]
+      driven_by :remote_chrome
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+      Capybara.server_port = 4444
+      Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+      Capybara.ignore_hidden_elements = false
+    else
+      driven_by :selenium_chrome_headless
+    end
   end
 
   # You can uncomment this line to turn off ActiveRecord support entirely.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,7 @@ Capybara.register_driver :remote_chrome do |app|
   options.add_argument('no-sandbox')
   options.add_argument('headless')
   options.add_argument('disable-gpu')
-  options.add_argument('window-size=1680,1050')
+  options.add_argument('disable-dev-shm-usage')
+  options.add_argument('window-size=1440,990')
   Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
 end

--- a/spec/system/event_spec.rb
+++ b/spec/system/event_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "Events", type: :system do
+  describe "予定を立てる" do
+      let!(:game) { create(:game, title: "FF14") }
+      let!(:data_center) { create(:data_center, name: "mana", game: game) }
+
+    it "予定を立てることができる", js: true do
+      event = Event.create!(
+        name: "test_event",
+        game: game,
+        data_center: data_center,
+        event_times_attributes: [
+          { start_time: Time.zone.parse("2023-10-01 10:00") }
+        ]
+      )
+      expect(event.name).to eq "test_event"
+    end
+
+    it "日付未入力だと予定を立てることができない", js: true do
+      event = Event.create(
+        name: "test_event",
+        game: nil,
+        data_center: nil,
+      )
+      expect(event).not_to be_valid
+    end
+  end
+end

--- a/spec/system/schedule_inputs_spec.rb
+++ b/spec/system/schedule_inputs_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "ScheduleInputs", type: :system do
+  before do
+    @event = build(:event)
+    @event.event_times.build(start_time: "2025-10-01 20:00")
+    @event.save!
+  end
+
+  describe "予定入力" do
+    it "参加者が予定入力フォームを参照できる", js: true do
+      # イベント共有URLへアクセス（例: /events/:url/token）
+      visit "/events/url/#{@event.url}/schedule_inputs"
+      click_on "プレイヤー予定追加"
+      expect(page).to have_content "日程登録"
+    end
+
+    it "予定入力ができる", js: true do
+      visit "/events/url/#{@event.url}/schedule_inputs"
+      click_on "プレイヤー予定追加"
+      fill_in "プレイヤー名", with: "Test Player"
+      select "ヒーラー", from: "ジョブor武器(候補にない場合は未入力)"
+      within("div#response_ok_#{@event.event_times.first.id}") rescue nil
+      choose("response_ok_#{@event.event_times.first.id}", allow_label_click: true)
+      click_on "登録"
+      expect(page).to have_content "登録完了しました"
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Users", type: :system do
     it "つかいかたにアクセスできる" do
       visit root_path
       click_link "つかいかた"
-      expect(page).to have_content "主催者の方"
+      expect(page).to have_text("主催者の方", wait: 5)
     end
 
     it "予定を立てるにアクセスできる" do
@@ -52,7 +52,7 @@ RSpec.describe "Users", type: :system do
     it "githubにアクセスできる" do
       visit root_path
       click_link "Github"
-      expect(page).to have_content "Gamers_Planner"
+      expect(page).to have_text("Gamers_Planner", wait: 5)
     end
  end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,21 +1,91 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  let(:user) { create(:user) }
-
   describe "ログイン前" do
     it "ユーザー登録画面に遷移できる" do
       visit new_user_path
-      expect(page).to have_content "ユーザー登録"
+      expect(page).to have_content "新規登録"
     end
+
     it "ユーザー登録ができる" do
       visit new_user_path
       fill_in "名前", with: "Test User"
       fill_in "メールアドレス", with: "test@example.com"
       fill_in "パスワード", with: "password"
-      fill_in "パスワード確認", with: "password"
+      fill_in "パスワード（確認）", with: "password"
       click_button "保存"
-      expect(page).to have_content "確認メールを送信しました"
+      expect(page).to have_content "確認メールを送信しました。メールアドレスを確認して下さい"
+    end
+
+    it "つかいかたにアクセスできる" do
+      visit root_path
+      click_link "つかいかた"
+      expect(page).to have_content "主催者の方"
+    end
+
+    it "予定を立てるにアクセスできる" do
+      visit root_path
+      within("header") do
+      click_link "予定を立てる"
+      end
+      expect(page).to have_content "予定を立てる"
+    end
+
+    it "プライバシーポリシーにアクセスできる" do
+      visit root_path
+      click_link "プライバシーポリシー"
+      expect(page).to have_content "プライバシーポリシー"
+    end
+
+    it "利用規約にアクセスできる" do
+      visit root_path
+      click_link "利用規約"
+      expect(page).to have_content "利用規約"
+    end
+
+    it "お問い合わせにアクセスできる" do
+      visit root_path
+      click_link "お問い合わせ"
+      expect(page).to have_content "お問い合わせ"
+    end
+
+    it "githubにアクセスできる" do
+      visit root_path
+      click_link "Github"
+      expect(page).to have_content "Gamers_Planner"
+    end
+ end
+
+  describe "ログイン後" do
+    let(:user) do
+      create(:user, :activated, email: "dadatest_6@example.com")
+    end
+
+    before do
+      visit new_login_path
+      fill_in "メールアドレス", with: user.email
+      fill_in "パスワード", with: "password"
+      click_button "ログイン"
+      expect(page).to have_content("ログインしました")
+    end
+
+    it "マイページにアクセスできる" do
+      visit root_path
+        find("#dropdownDefaultButton").click
+        click_link "マイページ"
+      expect(page).to have_content "予定表一覧"
+    end
+
+    it "ログアウトできる" do
+      visit root_path
+        find("#dropdownDefaultButton").click
+        click_link "ログアウト"
+      expect(page).to have_content "ログアウトしました"
+    end
+
+    it "Discordbot連携ボタンが表示される" do
+      visit manual_show_path(button3: true)
+      expect(page).to have_content "Bot連携"
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -51,8 +51,14 @@ RSpec.describe "Users", type: :system do
 
     it "githubにアクセスできる" do
       visit root_path
-      click_link "Github"
-      expect(page).to have_text("Gamers_Planner", wait: 5)
+
+      new_window = window_opened_by do
+        click_link "Github"
+      end
+
+      within_window new_window do
+        expect(page).to have_title(/Gamers_Planner/)
+      end
     end
  end
 


### PR DESCRIPTION
close #17 
close #95 

## 追加した点
①Rspecにシステムテストを追加。以下の点をテストする。
    ・ログイン前後で予定入力機能以外のすべてのページが閲覧できる。
    ・主催者は予定入力機能で予定を立てることができる。
　・参加者は予定入力機能で予定を入力することができる。

[![Image from Gyazo](https://i.gyazo.com/92aba2f4b5d19bf7fe2459f80beb5fba.png)](https://gyazo.com/92aba2f4b5d19bf7fe2459f80beb5fba)

②workflow配下のci.ymlへRspecテストを追加。