### PR TITLE
fix:マニュアル誤字修正とテストコード編集(fixes #10, #17)

### DIFF
--- a/app/views/manual/show.html.erb
+++ b/app/views/manual/show.html.erb
@@ -1,5 +1,8 @@
 <div style="background-image: url('<%= asset_path("back_ground.webp") %>');" class="bg-custom min-h-screen flex flex-col items-center pt-10 font-mplus">
   <div class="divide-y bg-white w-full max-w-6xl mx-auto p-8 overflow-y-auto" style="max-height: calc(100vh - 160px);">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-3xl font-extrabold text-center text-black">Manuals</h2>
+    </div>
     <div class="grid grid-cols-1 lg:grid-cols-4 gap-8">
       <div class="flex flex-col text-left lg:text-left lg:col-span-3">
         <div class="flex items-center justify-start">
@@ -17,7 +20,7 @@
            <span class="text-black text-xs sm:text-base">開始時間を編集してください。</span>
           <span class="mt-4 text-black text-xs sm:text-base">日程候補から指定した日付を編集可能（複数選択可能）</span>
            <%= image_tag "manual_1.png", class: "w-50 h-50 object-cover" %>
-          <span class="mt-4 text-black text-xs sm:text-base">③登録をボタンを押すと予定表URLが出力されます。</span>
+          <span class="mt-4 text-black text-xs sm:text-base">③登録ボタンを押すと予定表URLが出力されます。</span>
           <span class="text-black text-xs sm:text-base">参加者へ送信してください。</span>
           <%= image_tag "manual_2.png", class: "w-50 h-50 object-cover" %>
         <% end %>
@@ -40,7 +43,7 @@
             <%= image_tag "manual_3.png", class: "w-[300px] h-[250px] object-cover" %>
           <span class="mt-4 text-black text-xs sm:text-base">②プレイヤー名と、ジョブ名や使用武器をプルダウンから選択して下さい。</span>
             <span class="mt-4 text-black text-xs sm:text-base">③自分の活動可能日程を〇✕△で選択して下さい。</span>
-            <span class="mt-4 text-black text-xs sm:text-base">（△で参加が微妙な場合は備考記入欄へ記入。あわせてプレイヤー名も記入する。）</span>
+            <span class="text-black text-xs sm:text-base">（△で参加が微妙な場合は備考記入欄へ記入。あわせてプレイヤー名も記入する。）</span>
             <%= image_tag "manual_4.png", class: "w-50 h-50 object-cover" %>
           <span class="mt-4 text-black text-xs sm:text-base">④登録ボタンを押して、日程入力完了です。予定を変更したい場合は、作成された予定表のプレイヤー名をクリックしてください。</span>
             <%= image_tag "manual_5.png", class: "w-[300px] h-[150px] object-cover" %>
@@ -62,9 +65,9 @@
         <% if @show_details_3 %>
           <span class="mt-4 text-black text-xs sm:text-base">DiscordBotを導入する事によって活動日当日の17時に当日の活動有無を通知する事が可能です。</span>
           <span class="text-black text-xs text-red-500 sm:text-base">※1つのアカウントにつき、1つのDiscordサーバーと連携します。</span>
-          <span class="text-black text-xs sm:text-base">誤って招待した場合や他のサーバーで新規に通知したい場合は、botをキック後に下記手順に従い再度Bot連携して下さい。</span>
+          <span class="text-black text-xs sm:text-base">誤って招待した場合や他のサーバーで新規に通知したい場合は、Botをキック後に下記手順に従い再度Bot連携して下さい。</span>
           <br>
-          <span class="mt-4 text-black text-xs sm:text-base">①当サービスログイン後、下部「Bot連携」ボタンを押し、DICORDで日程を通知したいサーバーを選択後、</span>
+          <span class="mt-4 text-black text-xs sm:text-base">①当サービス<a href="/login/new" class="text-blue-500 underline">ログイン</a>後、下部「Bot連携」ボタンを押し、DICORDで日程を通知したいサーバーを選択後、</span>
           <span class="text-black text-xs sm:text-base">指示に沿って認証をしてください。（サーバー管理者の方は、Botを招待する権限が必要です。）</span>
           <%= image_tag "manual_6.png", class: "w-[300px] h-[250px] object-cover" %>
           <span class="mt-4 text-black text-xs sm:text-base">②Discordに移動し、通知を送信したいチャンネルで「!set_channel」をメッセージで送信してください。</span>
@@ -83,7 +86,7 @@
 
                   <%= link_to "Bot連携", "https://discord.com/oauth2/authorize?client_id=#{ENV['DISCORD_CLIENT_ID']}&permissions=8&scope=bot+identify&redirect_uri=#{CGI.escape(redirect_uri)}&response_type=code", target: "_blank", rel: "noopener noreferrer" %>
               <% else %>
-                <p>ログインするとBot連携が可能になります。</p>
+                <p>ログインするとBot連携ボタンに変わります</p>
               <% end %>
               </button>
             </div>

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "Users", type: :system do
     it "つかいかたにアクセスできる" do
       visit root_path
       click_link "つかいかた"
+
+      expect(page).to have_current_path(manual_show_path, wait: 5)
       expect(page).to have_text("Manuals", wait: 5)
     end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Users", type: :system do
     it "つかいかたにアクセスできる" do
       visit root_path
       click_link "つかいかた"
-      expect(page).to have_text("主催者の方", wait: 5)
+      expect(page).to have_text("Manuals", wait: 5)
     end
 
     it "予定を立てるにアクセスできる" do


### PR DESCRIPTION
fix #10 
fix #17 

## 変更した点
Rspecのシステムテストにて、manualページ遷移後に指定した文字列がCIテストにて正常にパスしない為、
編集。manualページの誤字を編集。