### PR TITLE
fix: rspec修正

### DIFF
--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Users", type: :system do
       end
 
       within_window new_window do
-        expect(page).to have_title(/Gamers_Planner/)
+        expect(page).to have_title(/Gamers_Planner/, wait: 5)
       end
     end
  end


### PR DESCRIPTION
リモートのrspecが通らない為
`expect(page).to have_title(/Gamers_Planner/, wait: 5)`
5秒間応答を待つよう修正。