### PR TITLE
feat: #140 カレンダー範囲選択実装

### DIFF
--- a/app/javascript/calendar.js
+++ b/app/javascript/calendar.js
@@ -12,25 +12,27 @@ export function initializeCalendar() {
             initialView: 'dayGridMonth',
             locale: jaLocale,
             selectable: true,
+            select: function(info) {
+                handleDateRangeSelect(info);
+            },
             dateClick: function(info) {
-                handleDateClick(info);
+                addDateToCandidates(new Date(info.dateStr));
             }
         });
         calendar.render();
     }
 }
 
-function handleDateClick(info) {
+function addDateToCandidates(date) {
     let dateCandidates = document.getElementById('date_candidates');
     let form = document.querySelector('form');
 
-    //クリックされた日付を「月/日 (曜日)」形式に整形
-    let date = new Date(info.dateStr);
-    let dateStr = `${date.getMonth() + 1}/${date.getDate()} (${['日', '月', '火', '水', '木', '金', '土'][date.getDay()]})`;
+    // 表示用フォーマット
+    let dateStr = `${date.getMonth() + 1}/${date.getDate()} (${['日','月','火','水','木','金','土'][date.getDay()]})`;
     let defaultTime = "00:00";
     let dateTimeStr = `${dateStr} ${defaultTime}`;
 
-    // すでに同じ日付が存在するか確認
+    // 既存コードの中身をほぼそのまま移動 (クリック時と同じ処理)
     let index = document.querySelectorAll('.date-group .dates input[type="hidden"]').length;
 
     let existingCandidate = dateCandidates.querySelector('.date-group');
@@ -66,12 +68,6 @@ function handleDateClick(info) {
         // 時間が変更されたら隠しフィールドも更新
         timeInput.addEventListener('change', function() {
             newDate.value = `${dateStr} ${timeInput.value}`;
-            console.log("Updated hidden input value:", newDate.value);
-
-            let hiddenInputInForm = form.querySelector(`input[name="event[event_times_attributes][${index}][start_time]"]`);
-            if (hiddenInputInForm) {
-                hiddenInputInForm.value = newDate.value;
-            }
         });
 
         // 日付け削除ボタン作成
@@ -79,16 +75,8 @@ function handleDateClick(info) {
         removeButton.type = 'button';
         removeButton.textContent = '×';
         removeButton.className = 'ml-2 px-2 py-1 text-white bg-red-500 rounded hover:bg-red-600';
-
-        // 削除ボタンのイベントリスナー
         removeButton.addEventListener('click', function() {
-            newDateContainer.remove(); // 表示削除
-            let hiddenInputInForm = form.querySelector(`input[name="event[event_times_attributes][${index}][start_time]"]`);
-            if (hiddenInputInForm) {
-                hiddenInputInForm.remove(); // フォームの隠しフィールドも削除
-            }
-
-            // すべての候補が削除された場合、.date-group も削除
+            newDateContainer.remove();
             if (existingDatesContainer.children.length === 0) {
                 existingCandidate.remove();
             }
@@ -102,5 +90,20 @@ function handleDateClick(info) {
 
         // フォームにも追加
         form.appendChild(newDate.cloneNode(true));
+    }
+}
+
+function handleDateRangeSelect(info) {
+    // info.start, info.end は Date オブジェクト
+    // FullCalendar の仕様で end は「翌日0時」になるので -1日して調整
+    let startDate = new Date(info.start);
+    let endDate = new Date(info.end);
+    endDate.setDate(endDate.getDate() - 1);
+
+    // 選択範囲の日付を1日ずつループ
+    let currentDate = new Date(startDate);
+    while (currentDate <= endDate) {
+        addDateToCandidates(currentDate);
+        currentDate.setDate(currentDate.getDate() + 1);
     }
 }


### PR DESCRIPTION
close #140 

## 追加した点
予定を立てる画面のカレンダーを範囲選択できるよう実装。
[![Image from Gyazo](https://i.gyazo.com/d4750b480f97a10f00a3db2a658bfd52.gif)](https://gyazo.com/d4750b480f97a10f00a3db2a658bfd52)
calender.jsにて範囲選択の場合は

> handleDateRangeSelect(info);

クリックの場合は

> addDateToCandidates(new Date(info.dateStr));

でそれぞれ処理を分けて実装し、範囲選択の場合の処理を下記に追加。

> function handleDateRangeSelect(info) 
～